### PR TITLE
Fix: Ensure merge script includes all columns

### DIFF
--- a/FPL_Data_2025-26/merged_gws.csv
+++ b/FPL_Data_2025-26/merged_gws.csv
@@ -1,690 +1,695 @@
-Web name,Position,Team,Cost,Selected,Form,Status,Minutes,Goals,Assist,Saves,GC,Season Goals,Season Assists,xA,xG,xGI,xGC,CS,OGs,Pens Missed,Pens Saved,Yellow cards,Red cards,Starts,Was home,Team H Score,Team A Score,Opponent Team,Influence,Creativity,Threat,ICT Index,Bps,GW Points,Transfers In,Transfers Out,Next Fixture,GW
-Raya,GKP,Arsenal,5.5,16.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Arrizabalaga,GKP,Arsenal,4.5,1.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Hein,GKP,Arsenal,4.0,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Setford,GKP,Arsenal,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Gabriel,DEF,Arsenal,6.0,18.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Saliba,DEF,Arsenal,6.0,14.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Calafiori,DEF,Arsenal,5.5,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-J.Timber,DEF,Arsenal,5.5,2.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Kiwior,DEF,Arsenal,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Lewis-Skelly,DEF,Arsenal,5.5,4.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-White,DEF,Arsenal,5.5,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Zinchenko,DEF,Arsenal,5.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Clarke,DEF,Arsenal,4.0,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Kacurri,DEF,Arsenal,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Nichols,DEF,Arsenal,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Saka,MID,Arsenal,10.0,17.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Ødegaard,MID,Arsenal,8.0,3.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Madueke,MID,Arsenal,7.0,1.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Martinelli,MID,Arsenal,7.0,1.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Trossard,MID,Arsenal,7.0,0.4,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Rice,MID,Arsenal,6.5,7.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Merino,MID,Arsenal,6.0,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Fábio Vieira,MID,Arsenal,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Nørgaard,MID,Arsenal,5.5,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Nwaneri,MID,Arsenal,5.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Zubimendi,MID,Arsenal,5.5,2.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Nelson,MID,Arsenal,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Kabia,MID,Arsenal,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Sambi,MID,Arsenal,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Havertz,FWD,Arsenal,7.5,1.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-G.Jesus,FWD,Arsenal,6.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Mosquera,DEF,Arsenal,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Gyökeres,FWD,Arsenal,9.0,26.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Home),1
-Martinez,GKP,Aston Villa,5.0,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-M.Bizot,GKP,Aston Villa,4.5,0.5,7.0,a,90,0,0,3,0,0,0,0.0,0.0,0.0,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,19.6,0.0,0.0,2.0,29,7,0,0,Brentford (Home),1
-Gauci,GKP,Aston Villa,4.0,0.3,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Marschall,GKP,Aston Villa,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Cash,DEF,Aston Villa,4.5,2.5,8.0,a,90,0,0,0,0,0,0,0.0,0.0,0.0,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,37.6,1.1,2.0,4.1,25,8,0,0,Brentford (Home),1
-Digne,DEF,Aston Villa,4.5,2.0,6.0,a,90,0,0,0,0,0,0,0.01,0.0,0.01,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,11.6,5.8,0.0,1.7,22,6,0,0,Brentford (Home),1
-Konsa,DEF,Aston Villa,4.5,21.9,3.0,s,65,0,0,0,0,0,0,0.01,0.0,0.01,1.11,1,0,0,0,0,1,1,True,0.0,0.0,Newcastle,1.8,1.1,0.0,0.3,15,3,0,0,Brentford (Home),1
-Maatsen,DEF,Aston Villa,4.5,0.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Mings,DEF,Aston Villa,4.5,1.0,6.0,a,90,0,0,0,0,0,0,0.0,0.0,0.0,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,13.0,3.7,0.0,1.7,25,6,0,0,Brentford (Home),1
-Pau,DEF,Aston Villa,4.5,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-A.García,DEF,Aston Villa,4.0,0.3,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Alex Moreno,DEF,Aston Villa,4.0,10.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Bogarde,DEF,Aston Villa,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Sousa,DEF,Aston Villa,4.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Yasin,DEF,Aston Villa,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Rogers,MID,Aston Villa,7.0,10.0,3.0,a,90,0,0,0,0,0,0,0.05,0.0,0.05,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,7.2,20.1,4.0,3.1,7,3,0,0,Brentford (Home),1
-Tielemans,MID,Aston Villa,6.0,2.3,3.0,a,90,0,0,0,0,0,0,0.01,0.0,0.01,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,4.0,1.1,0.0,0.5,5,3,0,0,Brentford (Home),1
-Bailey,MID,Aston Villa,5.5,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Buendía,MID,Aston Villa,5.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Iling Jr,MID,Aston Villa,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-J.Ramsey,MID,Aston Villa,5.5,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Malen,MID,Aston Villa,5.5,1.8,1.0,a,6,0,0,0,0,0,0,0.0,0.03,0.03,0.1,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,3.0,0.0,17.0,2.0,4,1,0,0,Brentford (Home),1
-McGinn,MID,Aston Villa,5.5,0.7,3.0,a,83,0,0,0,0,0,0,0.09,0.0,0.09,1.33,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,5.0,19.3,6.0,3.0,10,3,0,0,Brentford (Home),1
-Barkley,MID,Aston Villa,5.0,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Barrenechea,MID,Aston Villa,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Dobbin,MID,Aston Villa,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Kamara,MID,Aston Villa,5.0,0.2,2.0,a,90,0,0,0,0,0,0,0.03,0.05,0.08,1.43,1,0,0,0,1,0,1,True,0.0,0.0,Newcastle,13.8,2.2,17.0,3.3,13,2,0,0,Brentford (Home),1
-Onana,MID,Aston Villa,5.0,1.6,5.0,a,90,0,0,0,0,0,0,0.01,0.0,0.01,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,19.4,3.0,0.0,2.2,19,5,0,0,Brentford (Home),1
-Broggio,MID,Aston Villa,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Dendoncker,MID,Aston Villa,4.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Jimoh-Aloba,MID,Aston Villa,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Young,MID,Aston Villa,4.5,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Watkins,FWD,Aston Villa,9.0,27.4,2.0,a,90,0,0,0,0,0,0,0.01,0.12,0.13,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,10.6,12.2,27.0,5.0,12,2,0,0,Brentford (Home),1
-Redmond,FWD,Aston Villa,4.5,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Guessand,MID,Aston Villa,6.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Wright,GKP,Aston Villa,4.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Home),1
-Weiss,GKP,Burnley,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Green,GKP,Burnley,4.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Hladký,GKP,Burnley,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Roberts,DEF,Burnley,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Walker,DEF,Burnley,4.5,1.9,1.0,a,90,0,0,0,3,0,0,0.02,0.01,0.03,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,6.2,0.9,1.0,0.8,-3,1,0,0,Sunderland (Away),1
-Delcroix,DEF,Burnley,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Dodgson,DEF,Burnley,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Ekdal,DEF,Burnley,4.0,0.2,1.0,a,90,0,0,0,3,0,0,0.0,0.0,0.0,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,9.6,0.8,8.0,1.8,-5,1,0,0,Sunderland (Away),1
-Estève,DEF,Burnley,4.0,20.4,1.0,a,90,0,0,0,3,0,0,0.0,0.05,0.05,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,19.4,0.5,17.0,3.7,0,1,0,0,Sunderland (Away),1
-Hartman,DEF,Burnley,4.0,0.5,1.0,a,90,0,0,0,3,0,0,0.04,0.0,0.04,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,13.4,11.7,2.0,2.7,-2,1,0,0,Sunderland (Away),1
-Humphreys,DEF,Burnley,4.0,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Jordan,DEF,Burnley,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Lucas Pires,DEF,Burnley,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Sambo,DEF,Burnley,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Sonne,DEF,Burnley,4.0,0.1,1.0,a,73,0,0,0,3,0,0,0.08,0.03,0.11,2.09,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,4.8,16.0,6.0,2.7,-4,1,0,0,Sunderland (Away),1
-Tuanzebe,DEF,Burnley,4.0,2.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Worrall,DEF,Burnley,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Anthony,MID,Burnley,5.5,0.1,2.0,a,84,0,0,0,3,0,0,0.36,0.44,0.8,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,9.0,26.2,32.0,6.7,9,2,0,0,Sunderland (Away),1
-Benson,MID,Burnley,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Bruun Larsen,MID,Burnley,5.5,0.0,1.0,a,27,0,0,0,1,0,0,0.01,0.0,0.01,0.91,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,4.6,0.7,8.0,1.3,2,1,0,0,Sunderland (Away),1
-Boateng,MID,Burnley,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Churlinov,MID,Burnley,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Cullen,MID,Burnley,5.0,0.1,4.0,a,90,0,0,0,3,0,0,0.28,0.0,0.28,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,23.8,59.4,0.0,8.3,21,4,0,0,Sunderland (Away),1
-Edwards,MID,Burnley,5.0,0.1,1.0,a,5,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,3,1,0,0,Sunderland (Away),1
-Hannibal,MID,Burnley,5.0,0.1,2.0,a,62,0,0,0,2,0,0,0.01,0.03,0.04,1.41,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,0.0,1.7,5.0,0.6,8,2,0,0,Sunderland (Away),1
-Koleosho,MID,Burnley,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Laurent,MID,Burnley,5.0,0.0,2.0,a,62,0,0,0,2,0,0,0.13,0.11,0.24,1.41,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,10.6,11.2,20.0,4.2,11,2,0,0,Sunderland (Away),1
-Tchaouna,MID,Burnley,5.0,0.0,1.0,a,16,0,0,0,0,0,0,0.01,0.0,0.01,0.23,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,3.2,0.8,0.0,0.4,4,1,0,0,Sunderland (Away),1
-A.Ramsey,MID,Burnley,4.5,10.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Adewumi,MID,Burnley,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Banel,MID,Burnley,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Trésor,MID,Burnley,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Flemming,FWD,Burnley,5.5,0.2,1.0,a,16,0,0,0,0,0,0,0.0,0.0,0.0,0.23,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,3,1,0,0,Sunderland (Away),1
-Amdouni,FWD,Burnley,5.0,0.1,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Foster,FWD,Burnley,5.0,0.4,2.0,a,73,0,0,0,3,0,0,0.04,0.22,0.26,2.09,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,4.8,22.7,10.0,3.8,6,2,0,0,Sunderland (Away),1
-Barnes,FWD,Burnley,4.5,2.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Obafemi,FWD,Burnley,4.5,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Dúbravka,GKP,Burnley,4.0,34.8,2.0,a,90,0,0,3,3,0,0,0.0,0.0,0.0,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,25.8,0.0,0.0,2.6,5,2,0,0,Sunderland (Away),1
-Ugochukwu,MID,Burnley,5.0,0.0,1.0,a,27,0,0,0,1,0,0,0.0,0.05,0.05,0.91,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.3,3.0,0.1,1,1,0,0,Sunderland (Away),1
-Broja,FWD,Burnley,5.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,Sunderland (Away),1
-Neto,GKP,Bournemouth,4.5,0.2,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Petrović,GKP,Bournemouth,4.5,3.3,2.0,a,90,0,0,6,4,0,0,0.0,0.0,0.0,2.21,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,47.8,0.0,0.0,4.8,10,2,0,0,Wolves (Away),1
-Dennis,GKP,Bournemouth,4.0,1.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-McKenna,GKP,Bournemouth,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Paulsen,GKP,Bournemouth,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Zabarnyi,DEF,Bournemouth,5.0,0.1,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Senesi,DEF,Bournemouth,4.5,0.9,2.0,a,90,0,0,0,4,0,0,0.05,0.0,0.05,2.21,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,26.6,14.6,2.0,4.3,1,2,0,0,Wolves (Away),1
-Smith,DEF,Bournemouth,4.5,0.4,1.0,a,89,0,0,0,3,0,0,0.08,0.0,0.08,2.1,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,12.2,10.5,4.0,2.7,2,1,0,0,Wolves (Away),1
-Truffert,DEF,Bournemouth,4.5,0.7,0.0,a,90,0,0,0,4,0,0,0.13,0.0,0.13,2.21,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,18.2,19.1,0.0,3.7,-1,0,0,0,Wolves (Away),1
-Akinmboni,DEF,Bournemouth,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Bevan,DEF,Bournemouth,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Hill,DEF,Bournemouth,4.0,0.7,1.0,a,1,0,0,0,1,0,0,0.0,0.0,0.0,0.11,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,3.0,0.1,0.0,0.3,0,1,0,0,Wolves (Away),1
-J.Araujo,DEF,Bournemouth,4.0,1.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Mepham,DEF,Bournemouth,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Soler,DEF,Bournemouth,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Kluivert,MID,Bournemouth,7.0,0.9,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Semenyo,MID,Bournemouth,7.0,7.2,15.0,a,90,2,0,0,4,2,0,0.02,0.91,0.93,2.21,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,66.4,1.3,32.0,10.0,42,15,0,0,Wolves (Away),1
-O.Dango,MID,Bournemouth,6.0,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Tavernier,MID,Bournemouth,5.5,0.4,4.0,a,90,0,0,0,4,0,0,0.06,0.32,0.38,2.21,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,24.6,14.1,33.0,7.2,20,4,0,0,Wolves (Away),1
-Adams,MID,Bournemouth,5.0,0.3,4.0,a,90,0,0,0,3,0,0,0.1,0.0,0.1,2.1,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,23.6,1.7,4.0,2.9,11,4,0,0,Wolves (Away),1
-Brooks,MID,Bournemouth,5.0,0.2,4.0,a,83,0,1,0,2,0,1,0.19,0.19,0.38,1.9,0,0,0,0,1,0,1,False,4.0,2.0,Liverpool,27.2,40.3,18.0,8.6,23,4,0,0,Wolves (Away),1
-Christie,MID,Bournemouth,5.0,0.1,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Cook,MID,Bournemouth,5.0,0.0,0.0,s,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Philip,MID,Bournemouth,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Scott,MID,Bournemouth,5.0,0.1,2.0,a,73,0,0,0,2,0,0,0.0,0.0,0.0,1.81,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,2.0,2.1,2.0,0.6,7,2,0,0,Wolves (Away),1
-Sinisterra,MID,Bournemouth,5.0,0.0,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Faivre,MID,Bournemouth,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-H.Traorè,MID,Bournemouth,4.5,0.5,4.0,a,16,0,1,0,2,0,1,0.0,0.0,0.0,0.4,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,21.2,10.0,0.0,3.1,12,4,0,0,Wolves (Away),1
-Sadi,MID,Bournemouth,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Silcott-Duberry,MID,Bournemouth,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Winterburn,MID,Bournemouth,4.5,0.1,1.0,a,6,0,0,0,2,0,0,0.0,0.0,0.0,0.31,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,3,1,0,0,Wolves (Away),1
-Evanilson,FWD,Bournemouth,7.0,2.0,1.0,a,90,0,0,0,4,0,0,0.0,0.29,0.29,2.21,0,0,0,0,1,0,1,False,4.0,2.0,Liverpool,0.0,0.6,17.0,1.6,-1,1,0,0,Wolves (Away),1
-Enes Ünal,FWD,Bournemouth,5.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Adu-Adjei,FWD,Bournemouth,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Kroupi.Jr,FWD,Bournemouth,4.5,1.0,1.0,a,1,0,0,0,1,0,0,0.0,0.0,0.0,0.11,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,2,1,0,0,Wolves (Away),1
-Diakité,DEF,Bournemouth,4.5,0.1,0.0,a,90,0,0,0,4,0,0,0.0,0.0,0.0,2.21,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,14.8,0.2,0.0,1.5,2,0,0,0,Wolves (Away),1
-Rees-Dottin,MID,Bournemouth,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,Wolves (Away),1
-Kelleher,GKP,Brentford,4.5,11.2,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Balcombe,GKP,Brentford,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Cox,GKP,Brentford,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Eyestone,GKP,Brentford,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Valdimarsson,GKP,Brentford,4.0,1.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Collins,DEF,Brentford,5.0,1.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Lewis-Potter,DEF,Brentford,5.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Ajer,DEF,Brentford,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Henry,DEF,Brentford,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Kayode,DEF,Brentford,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Pinnock,DEF,Brentford,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Roerslev,DEF,Brentford,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Van den Berg,DEF,Brentford,4.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Arthur,DEF,Brentford,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Fredrick,DEF,Brentford,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Hickey,DEF,Brentford,4.0,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Ji-soo,DEF,Brentford,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Meghoma,DEF,Brentford,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Schade,MID,Brentford,7.0,0.3,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Damsgaard,MID,Brentford,6.0,1.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Milambo,MID,Brentford,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Carvalho,MID,Brentford,5.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Henderson,MID,Brentford,5.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Janelt,MID,Brentford,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Jensen,MID,Brentford,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Nunes,MID,Brentford,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Onyeka,MID,Brentford,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Yarmoliuk,MID,Brentford,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Donovan,MID,Brentford,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Konak,MID,Brentford,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Maghoma,MID,Brentford,4.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Peart-Harris,MID,Brentford,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Trevitt,MID,Brentford,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Wissa,FWD,Brentford,7.5,2.5,0.0,n,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Thiago,FWD,Brentford,6.0,0.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Morgan,FWD,Brentford,4.5,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,Nott'm Forest (Home),1
-Steele,GKP,Brighton,4.5,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Verbruggen,GKP,Brighton,4.5,7.9,2.0,a,90,0,0,1,1,0,0,0.0,0.0,0.0,0.69,0,0,0,0,0,0,1,True,1.0,1.0,Fulham,14.0,0.0,0.0,1.4,9,2,0,0,Everton (Home),1
-McGill,GKP,Brighton,4.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Rushworth,GKP,Brighton,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Scherpen,GKP,Brighton,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Boscagli,DEF,Brighton,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Coppola,DEF,Brighton,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-De Cuyper,DEF,Brighton,4.5,6.5,2.0,a,90,0,0,0,1,0,0,0.09,0.0,0.09,0.69,0,0,0,0,0,0,1,True,1.0,1.0,Fulham,12.0,26.7,2.0,4.1,5,2,0,0,Everton (Home),1
-Dunk,DEF,Brighton,4.5,1.3,2.0,a,90,0,0,0,1,0,0,0.0,0.09,0.09,0.69,0,0,0,0,0,0,1,True,1.0,1.0,Fulham,16.6,1.8,7.0,2.5,16,2,0,0,Everton (Home),1
-Estupiñan,DEF,Brighton,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-F.Kadıoğlu,DEF,Brighton,4.5,0.2,0.0,a,21,0,0,0,1,0,0,0.0,0.0,0.0,0.21,0,0,0,0,1,0,0,True,1.0,1.0,Fulham,0.0,1.3,0.0,0.1,-5,0,0,0,Everton (Home),1
-Igor,DEF,Brighton,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Lamptey,DEF,Brighton,4.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Van Hecke,DEF,Brighton,4.5,1.2,2.0,a,90,0,0,0,1,0,0,0.13,0.0,0.13,0.69,0,0,0,0,0,0,1,True,1.0,1.0,Fulham,27.8,1.1,0.0,2.9,15,2,0,0,Everton (Home),1
-Veltman,DEF,Brighton,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Webster,DEF,Brighton,4.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Cashin,DEF,Brighton,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Slater,DEF,Brighton,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Tasker,DEF,Brighton,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Mitoma,MID,Brighton,6.5,7.2,2.0,a,82,0,0,0,0,0,0,0.04,0.07,0.11,0.49,1,0,0,0,1,0,1,True,1.0,1.0,Fulham,0.0,2.4,10.0,0.8,-2,2,0,0,Everton (Home),1
-Georginio,MID,Brighton,6.0,1.4,6.0,a,68,0,1,0,0,0,1,0.0,0.07,0.07,0.49,1,0,0,0,0,0,1,True,1.0,1.0,Fulham,0.2,1.2,15.0,1.6,13,6,0,0,Everton (Home),1
-March,MID,Brighton,6.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Minteh,MID,Brighton,6.0,1.2,3.0,a,68,0,0,0,0,0,0,0.02,0.09,0.11,0.49,1,0,0,0,0,0,1,True,1.0,1.0,Fulham,0.4,4.7,12.0,1.7,7,3,0,0,Everton (Home),1
-Enciso,MID,Brighton,5.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Gruda,MID,Brighton,5.5,0.0,1.0,a,7,0,0,0,1,0,0,0.0,0.38,0.38,0.21,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.2,0.3,4.0,0.5,-2,1,0,0,Everton (Home),1
-Hinshelwood,MID,Brighton,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-O'Riley,MID,Brighton,5.5,0.3,10.0,a,87,1,0,0,0,1,0,0.14,0.79,0.93,0.49,1,0,0,0,0,0,1,True,1.0,1.0,Fulham,45.8,44.3,23.0,11.3,24,10,0,0,Everton (Home),1
-Sima,MID,Brighton,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Ayari,MID,Brighton,5.0,0.2,3.0,a,90,0,0,0,1,0,0,0.12,0.0,0.12,0.69,0,0,0,0,0,0,1,True,1.0,1.0,Fulham,7.0,3.2,2.0,1.2,20,3,0,0,Everton (Home),1
-Baleba,MID,Brighton,5.0,4.9,3.0,a,68,0,0,0,0,0,0,0.01,0.02,0.03,0.49,1,0,0,0,0,0,1,True,1.0,1.0,Fulham,5.0,12.0,1.0,1.8,9,3,0,0,Everton (Home),1
-Buonanotte,MID,Brighton,5.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Gomez,MID,Brighton,5.0,0.1,0.0,a,21,0,0,0,1,0,0,0.03,0.03,0.06,0.21,0,0,0,0,1,0,0,True,1.0,1.0,Fulham,7.6,11.4,7.0,2.6,7,0,0,0,Everton (Home),1
-Milner,MID,Brighton,5.0,0.1,1.0,a,2,0,0,0,1,0,0,0.0,0.0,0.0,0.21,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,3,1,0,0,Everton (Home),1
-Sarmiento,MID,Brighton,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Watson,MID,Brighton,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Wieffer,MID,Brighton,5.0,0.1,4.0,a,90,0,0,0,1,0,0,0.02,0.02,0.04,0.69,0,0,0,0,0,0,1,True,1.0,1.0,Fulham,24.8,2.6,21.0,4.8,18,4,0,0,Everton (Home),1
-Yalcouye,MID,Brighton,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Knight,MID,Brighton,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Mazilu,MID,Brighton,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Moran,MID,Brighton,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Welbeck,FWD,Brighton,6.5,4.5,1.0,a,21,0,0,0,1,0,0,0.0,0.0,0.0,0.21,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,2.2,1.6,2.0,0.6,3,1,0,0,Everton (Home),1
-Ferguson,FWD,Brighton,5.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Tzimas,FWD,Brighton,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Kostoulas,FWD,Brighton,5.0,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Home),1
-Sánchez,GKP,Chelsea,5.0,25.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Jörgensen,GKP,Chelsea,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Penders,GKP,Chelsea,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Slonina,GKP,Chelsea,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Cucurella,DEF,Chelsea,6.0,19.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-James,DEF,Chelsea,5.5,5.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Chalobah,DEF,Chelsea,5.0,1.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Colwill,DEF,Chelsea,5.0,0.4,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Gusto,DEF,Chelsea,5.0,1.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-B.Badiashile,DEF,Chelsea,4.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Fofana,DEF,Chelsea,4.5,0.2,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-M.Sarr,DEF,Chelsea,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Tosin,DEF,Chelsea,4.5,1.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Acheampong,DEF,Chelsea,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Anselmino,DEF,Chelsea,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Palmer,MID,Chelsea,10.5,63.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Neto,MID,Chelsea,7.0,3.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Enzo,MID,Chelsea,6.5,3.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Estêvão,MID,Chelsea,6.5,1.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Gittens,MID,Chelsea,6.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Nkunku,MID,Chelsea,6.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Caicedo,MID,Chelsea,5.5,5.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-George,MID,Chelsea,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Lavia,MID,Chelsea,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Mudryk,MID,Chelsea,5.0,0.0,0.0,s,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Andrey Santos,MID,Chelsea,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-D.Essugo,MID,Chelsea,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Paez,MID,Chelsea,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-João Pedro,FWD,Chelsea,7.5,56.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Delap,FWD,Chelsea,6.5,4.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-N.Jackson,FWD,Chelsea,6.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Hato,DEF,Chelsea,5.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,Crystal Palace (Away),1
-Henderson,GKP,Crystal Palace,5.0,7.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Benitez,GKP,Crystal Palace,4.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Matthews,GKP,Crystal Palace,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Muñoz,DEF,Crystal Palace,5.5,8.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Lacroix,DEF,Crystal Palace,5.0,1.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Mitchell,DEF,Crystal Palace,5.0,1.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Sosa,DEF,Crystal Palace,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Guéhi,DEF,Crystal Palace,4.5,12.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Richards,DEF,Crystal Palace,4.5,1.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Chadi Riad,DEF,Crystal Palace,4.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Clyne,DEF,Crystal Palace,4.0,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Holding,DEF,Crystal Palace,4.0,0.1,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Kporha,DEF,Crystal Palace,4.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Eze,MID,Crystal Palace,7.5,10.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Sarr,MID,Crystal Palace,6.5,5.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Doucouré,MID,Crystal Palace,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Esse,MID,Crystal Palace,5.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Hughes,MID,Crystal Palace,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Kamada,MID,Crystal Palace,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Lerma,MID,Crystal Palace,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Wharton,MID,Crystal Palace,5.0,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Agbinone,MID,Crystal Palace,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Ahamada,MID,Crystal Palace,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Devenny,MID,Crystal Palace,4.5,1.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Ebiowei,MID,Crystal Palace,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-J.Rak-Sakyi,MID,Crystal Palace,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-M.França,MID,Crystal Palace,4.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Ozoh,MID,Crystal Palace,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Rodney,MID,Crystal Palace,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Umeh,MID,Crystal Palace,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Mateta,FWD,Crystal Palace,7.5,9.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Nketiah,FWD,Crystal Palace,5.5,0.4,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Édouard,FWD,Crystal Palace,5.0,1.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Marsh,FWD,Crystal Palace,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Home),1
-Dewsbury-Hall,MID,Everton,5.0,4.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Pickford,GKP,Everton,5.5,11.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Travers,GKP,Everton,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Tyrer,GKP,Everton,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Branthwaite,DEF,Everton,5.5,0.7,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Tarkowski,DEF,Everton,5.5,7.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Mykolenko,DEF,Everton,5.0,0.9,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-O'Brien,DEF,Everton,5.0,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Coleman,DEF,Everton,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Keane,DEF,Everton,4.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Patterson,DEF,Everton,4.5,0.0,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Dixon,DEF,Everton,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Welch,DEF,Everton,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Ndiaye,MID,Everton,6.5,11.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-McNeil,MID,Everton,6.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Alcaraz,MID,Everton,5.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Gana,MID,Everton,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Garner,MID,Everton,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Iroegbunam,MID,Everton,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Armstrong,MID,Everton,4.5,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Bates,MID,Everton,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Ebere,MID,Everton,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Heath,MID,Everton,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Metcalfe,MID,Everton,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Barry,FWD,Everton,6.0,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Beto,FWD,Everton,5.5,8.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Y.Chermiti,FWD,Everton,5.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Sherif,FWD,Everton,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Grealish,MID,Everton,6.5,3.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Aznou,DEF,Everton,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,Leeds (Home),1
-Leno,GKP,Fulham,5.0,1.7,3.0,a,90,0,0,3,1,0,0,0.0,0.0,0.0,1.54,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,23.2,0.0,0.0,2.3,15,3,0,0,Man Utd (Away),1
-Benda,GKP,Fulham,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Away),1
-Robinson,DEF,Fulham,5.0,0.9,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Away),1
-Andersen,DEF,Fulham,4.5,3.1,2.0,a,90,0,0,0,1,0,0,0.01,0.0,0.01,1.54,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,15.2,0.9,4.0,2.0,13,2,0,0,Man Utd (Away),1
-Bassey,DEF,Fulham,4.5,0.5,1.0,a,90,0,0,0,1,0,0,0.01,0.0,0.01,1.54,0,0,0,0,1,0,1,False,1.0,1.0,Brighton,10.0,1.6,0.0,1.2,1,1,0,0,Man Utd (Away),1
-Castagne,DEF,Fulham,4.5,0.1,1.0,a,6,0,0,0,0,0,0,0.12,0.0,0.12,0.47,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,2.2,4.7,2.0,0.9,4,1,0,0,Man Utd (Away),1
-Diop,DEF,Fulham,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Away),1
-J.Cuenca,DEF,Fulham,4.5,0.0,2.0,a,83,0,0,0,1,0,0,0.01,0.0,0.01,1.07,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,9.0,1.2,4.0,1.4,12,2,0,0,Man Utd (Away),1
-Tete,DEF,Fulham,4.5,0.2,2.0,a,90,0,0,0,1,0,0,0.01,0.0,0.01,1.54,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,12.8,1.6,0.0,1.4,17,2,0,0,Man Utd (Away),1
-Amissah,DEF,Fulham,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Away),1
-Iwobi,MID,Fulham,6.5,1.6,2.0,a,65,0,0,0,1,0,0,0.25,0.01,0.26,1.05,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,9.6,40.5,3.0,5.3,10,2,0,0,Man Utd (Away),1
-Smith Rowe,MID,Fulham,6.0,1.0,1.0,a,13,0,0,0,0,0,0,0.0,0.06,0.06,0.47,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.2,2.0,2.0,0.4,2,1,0,0,Man Utd (Away),1
-Adama,MID,Fulham,5.5,0.3,1.0,a,24,0,0,0,0,0,0,0.0,0.0,0.0,0.5,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.8,0.0,0.0,1,1,0,0,Man Utd (Away),1
-Andreas,MID,Fulham,5.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Away),1
-Sessegnon,MID,Fulham,5.5,0.0,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Away),1
-Wilson,MID,Fulham,5.5,1.0,5.0,a,90,0,1,0,1,0,1,0.02,0.06,0.08,1.54,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,3.0,5.4,15.0,2.3,17,5,0,0,Man Utd (Away),1
-Berge,MID,Fulham,5.0,0.1,2.0,a,65,0,0,0,1,0,0,0.01,0.0,0.01,1.05,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,1.2,0.7,0.0,0.2,3,2,0,0,Man Utd (Away),1
-Cairney,MID,Fulham,5.0,0.0,0.0,a,24,0,0,0,0,0,0,0.0,0.0,0.0,0.5,0,0,0,0,1,0,0,False,1.0,1.0,Brighton,0.0,0.4,0.0,0.0,-3,0,0,0,Man Utd (Away),1
-Lukić,MID,Fulham,5.0,0.1,2.0,a,90,0,0,0,1,0,0,0.01,0.0,0.01,1.54,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,2.0,12.3,2.0,1.6,9,2,0,0,Man Utd (Away),1
-Godo,MID,Fulham,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Away),1
-Harris,MID,Fulham,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Away),1
-King,MID,Fulham,4.5,0.9,2.0,a,76,0,0,0,1,0,0,0.13,0.18,0.31,1.07,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,12.4,13.8,27.0,5.3,10,2,0,0,Man Utd (Away),1
-Reed,MID,Fulham,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Away),1
-Raúl,FWD,Fulham,6.5,2.2,2.0,a,65,0,0,0,1,0,0,0.0,0.27,0.27,1.05,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,0.0,3.3,11.0,0.7,0,2,0,0,Man Utd (Away),1
-Muniz,FWD,Fulham,5.5,2.0,7.0,a,24,1,0,0,0,1,0,0.0,0.15,0.15,0.5,0,0,0,0,1,0,0,False,1.0,1.0,Brighton,31.0,0.0,33.0,6.4,25,7,0,0,Man Utd (Away),1
-Lecomte,GKP,Fulham,4.0,0.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,Man Utd (Away),1
-Meslier,GKP,Leeds,4.5,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Cairns,GKP,Leeds,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Darlow,GKP,Leeds,4.0,3.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Bogle,DEF,Leeds,4.5,0.2,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Struijk,DEF,Leeds,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Bijol,DEF,Leeds,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Bornauw,DEF,Leeds,4.0,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Byram,DEF,Leeds,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Gudmundsson,DEF,Leeds,4.0,2.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Rodon,DEF,Leeds,4.0,2.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Schmidt,DEF,Leeds,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Aaronson,MID,Leeds,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Gnonto,MID,Leeds,5.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Harrison,MID,Leeds,5.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-James,MID,Leeds,5.5,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Ampadu,MID,Leeds,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Greenwood,MID,Leeds,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Gruev,MID,Leeds,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Ramazani,MID,Leeds,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Tanaka,MID,Leeds,5.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Crew,MID,Leeds,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Gelhardt,MID,Leeds,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Gyabi,MID,Leeds,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Piroe,FWD,Leeds,5.5,2.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Bamford,FWD,Leeds,5.0,2.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Mateo Joseph,FWD,Leeds,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Nmecha,FWD,Leeds,5.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Longstaff,MID,Leeds,5.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Stach,MID,Leeds,5.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-Perri,GKP,Leeds,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Everton,0.0,0.0,0.0,0.0,0,0,0,0,Everton (Away),1
-A.Becker,GKP,Liverpool,5.5,11.6,1.0,a,90,0,0,1,2,0,0,0.01,0.0,0.01,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,13.6,0.0,0.0,1.4,8,1,0,0,Newcastle (Home),1
-Mamardashvili,GKP,Liverpool,4.5,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Pécsi,GKP,Liverpool,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Woodman,GKP,Liverpool,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Frimpong,DEF,Liverpool,6.0,31.1,1.0,a,59,0,0,0,0,0,0,0.01,0.01,0.02,0.81,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,5.4,1.3,2.0,0.9,8,1,0,0,Newcastle (Home),1
-Kerkez,DEF,Liverpool,6.0,6.7,0.0,a,59,0,0,0,0,0,0,0.01,0.0,0.01,0.81,0,0,0,0,1,0,1,True,4.0,2.0,Bournemouth,8.4,1.3,0.0,1.0,5,0,0,0,Newcastle (Home),1
-Robertson,DEF,Liverpool,6.0,1.4,0.0,a,30,0,0,0,2,0,0,0.04,0.0,0.04,0.89,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,5.4,4.1,2.0,1.2,-3,0,0,0,Newcastle (Home),1
-Virgil,DEF,Liverpool,6.0,24.0,3.0,a,90,0,0,0,2,0,0,0.01,0.18,0.19,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,49.4,0.9,25.0,7.5,11,3,0,0,Newcastle (Home),1
-Konaté,DEF,Liverpool,5.5,3.0,1.0,a,90,0,0,0,2,0,0,0.0,0.0,0.0,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,21.4,0.6,0.0,2.2,6,1,0,0,Newcastle (Home),1
-Bradley,DEF,Liverpool,5.0,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Gomez,DEF,Liverpool,5.0,0.1,1.0,a,18,0,0,0,1,0,0,0.0,0.0,0.0,0.21,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,2.4,0.4,0.0,0.3,-1,1,0,0,Newcastle (Home),1
-Tsimikas,DEF,Liverpool,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Nallo,DEF,Liverpool,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-R.Williams,DEF,Liverpool,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Ramsay,DEF,Liverpool,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-M.Salah,MID,Liverpool,14.5,54.4,8.0,a,90,1,0,0,2,1,0,0.11,0.26,0.37,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,49.0,33.8,51.0,13.4,36,8,0,0,Newcastle (Home),1
-Wirtz,MID,Liverpool,8.5,33.1,2.0,a,81,0,0,0,2,0,0,0.28,0.14,0.42,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,12.0,45.0,12.0,6.9,14,2,0,0,Newcastle (Home),1
-Luis Díaz,MID,Liverpool,8.0,0.1,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Gakpo,MID,Liverpool,7.5,7.6,7.0,a,90,1,0,0,2,1,0,0.44,0.2,0.64,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,48.2,39.6,46.0,13.4,34,7,0,0,Newcastle (Home),1
-Chiesa,MID,Liverpool,6.5,0.2,6.0,a,8,1,0,0,0,1,0,0.0,0.16,0.16,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,35.2,0.3,17.0,5.3,29,6,0,0,Newcastle (Home),1
-Mac Allister,MID,Liverpool,6.5,1.7,5.0,a,71,0,1,0,1,0,1,0.02,0.03,0.05,1.49,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,27.4,15.2,11.0,5.4,27,5,0,0,Newcastle (Home),1
-Szoboszlai,MID,Liverpool,6.5,2.1,2.0,a,90,0,0,0,2,0,0,0.09,0.1,0.19,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,16.0,29.8,24.0,7.0,17,2,0,0,Newcastle (Home),1
-C.Jones,MID,Liverpool,5.5,0.1,1.0,a,18,0,0,0,1,0,0,0.04,0.0,0.04,0.21,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,3.2,10.9,0.0,1.4,4,1,0,0,Newcastle (Home),1
-Elliott,MID,Liverpool,5.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Gravenberch,MID,Liverpool,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Doak,MID,Liverpool,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Endo,MID,Liverpool,5.0,0.1,4.0,a,30,0,1,0,2,0,1,0.0,0.0,0.0,0.89,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,24.6,10.7,0.0,3.5,15,4,0,0,Newcastle (Home),1
-Bajcetic,MID,Liverpool,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-McConnell,MID,Liverpool,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Morton,MID,Liverpool,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Nyoni,MID,Liverpool,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Darwin,FWD,Liverpool,6.5,0.2,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Danns,FWD,Liverpool,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Ekitiké,FWD,Liverpool,8.5,17.2,11.0,a,71,1,1,0,1,1,1,0.02,1.14,1.16,1.49,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,52.8,24.4,37.0,11.4,37,11,0,0,Newcastle (Home),1
-Ngumoha,MID,Liverpool,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,Newcastle (Home),1
-Trafford,GKP,Man City,5.0,2.1,7.0,a,90,0,0,3,0,0,0,0.0,0.0,0.0,0.49,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,29.0,0.0,0.0,2.9,31,7,0,0,Spurs (Away),1
-Ederson M.,GKP,Man City,5.5,3.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Ortega Moreno,GKP,Man City,5.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Bettinelli,GKP,Man City,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Aït-Nouri,DEF,Man City,6.0,21.1,9.0,a,90,0,0,0,0,0,0,0.02,0.06,0.08,0.49,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,30.6,13.5,3.0,4.7,33,9,0,0,Spurs (Away),1
-Gvardiol,DEF,Man City,6.0,9.6,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Akanji,DEF,Man City,5.5,0.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Aké,DEF,Man City,5.5,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Khusanov,DEF,Man City,5.5,0.4,1.0,a,8,0,0,0,0,0,0,0.0,0.0,0.0,0.08,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,3.6,0.0,0.0,0.4,7,1,0,0,Spurs (Away),1
-Matheus N.,DEF,Man City,5.5,0.5,1.0,a,24,0,0,0,0,0,0,0.0,0.0,0.0,0.19,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,6.8,1.2,0.0,0.8,6,1,0,0,Spurs (Away),1
-Rúben,DEF,Man City,5.5,3.3,6.0,a,90,0,0,0,0,0,0,0.08,0.0,0.08,0.49,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,20.2,1.7,2.0,2.4,27,6,0,0,Spurs (Away),1
-Stones,DEF,Man City,5.5,0.7,6.0,a,81,0,0,0,0,0,0,0.01,0.0,0.01,0.4,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,15.0,2.2,0.0,1.7,27,6,0,0,Spurs (Away),1
-Lewis,DEF,Man City,5.0,1.0,11.0,a,65,0,1,0,0,0,1,0.53,0.0,0.53,0.29,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,29.0,13.0,8.0,5.0,41,11,0,0,Spurs (Away),1
-O’Reilly,DEF,Man City,5.0,0.2,0.0,a,24,0,0,0,0,0,0,0.01,0.0,0.01,0.19,0,0,0,0,1,0,0,False,0.0,4.0,Wolves,0.0,5.0,0.0,0.5,-2,0,0,0,Spurs (Away),1
-Vitor Reis,DEF,Man City,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Marmoush,MID,Man City,8.5,11.1,1.0,a,24,0,0,0,0,0,0,0.0,0.14,0.14,0.19,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.8,6.0,0.7,3,1,0,0,Spurs (Away),1
-Foden,MID,Man City,8.0,1.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Savinho,MID,Man City,7.0,1.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Bernardo,MID,Man City,6.5,0.8,3.0,a,65,0,0,0,0,0,0,0.44,0.0,0.44,0.29,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,22.0,62.1,4.0,8.8,25,3,0,0,Spurs (Away),1
-Cherki,MID,Man City,6.5,8.0,6.0,a,17,1,0,0,0,1,0,0.03,0.06,0.09,0.19,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,35.8,2.8,7.0,4.6,22,6,0,0,Spurs (Away),1
-Doku,MID,Man City,6.5,1.2,3.0,a,65,0,0,0,0,0,0,0.02,0.0,0.02,0.29,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,0.0,3.2,4.0,0.6,4,3,0,0,Spurs (Away),1
-Gündoğan,MID,Man City,6.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Rodrigo,MID,Man City,6.5,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Kovačić,MID,Man City,6.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-N.Gonzalez,MID,Man City,6.0,0.1,3.0,a,90,0,0,0,0,0,0,0.04,0.05,0.09,0.49,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,23.4,6.4,6.0,3.6,24,3,0,0,Spurs (Away),1
-Bobb,MID,Man City,5.5,0.2,6.0,a,90,0,1,0,0,0,1,0.07,0.0,0.07,0.49,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,24.6,25.3,10.0,6.0,25,6,0,0,Spurs (Away),1
-Echeverri,MID,Man City,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-McAtee,MID,Man City,5.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Reijnders,MID,Man City,5.5,21.3,10.0,a,90,1,1,0,0,1,1,0.21,0.12,0.33,0.49,1,0,0,0,1,0,1,False,0.0,4.0,Wolves,53.0,22.7,30.0,10.6,32,10,0,0,Spurs (Away),1
-Nypan,MID,Man City,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Phillips,MID,Man City,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,Spurs (Away),1
-Haaland,FWD,Man City,14.0,24.8,13.0,a,72,2,0,0,0,2,0,0.0,2.01,2.01,0.29,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,58.0,0.3,71.0,12.9,49,13,0,0,Spurs (Away),1
-Mbeumo,MID,Man Utd,8.0,13.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Bayindir,GKP,Man Utd,5.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Onana,GKP,Man Utd,5.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Harrison,GKP,Man Utd,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Heaton,GKP,Man Utd,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Mee,GKP,Man Utd,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-De Ligt,DEF,Man Utd,5.0,1.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Martinez,DEF,Man Utd,5.0,0.2,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Mazraoui,DEF,Man Utd,5.0,0.3,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-D.Leon,DEF,Man Utd,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Dalot,DEF,Man Utd,4.5,2.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Dorgu,DEF,Man Utd,4.5,6.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Maguire,DEF,Man Utd,4.5,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Shaw,DEF,Man Utd,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Yoro,DEF,Man Utd,4.5,1.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Amass,DEF,Man Utd,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Fredricson,DEF,Man Utd,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Heaven,DEF,Man Utd,4.0,1.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Malacia,DEF,Man Utd,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-B.Fernandes,MID,Man Utd,9.0,22.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Cunha,MID,Man Utd,8.0,7.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Rashford,MID,Man Utd,7.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Amad,MID,Man Utd,6.5,3.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Garnacho,MID,Man Utd,6.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Antony,MID,Man Utd,6.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Mount,MID,Man Utd,6.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Sancho,MID,Man Utd,6.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Casemiro,MID,Man Utd,5.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Mainoo,MID,Man Utd,5.0,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Ugarte,MID,Man Utd,5.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Collyer,MID,Man Utd,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Fitzgerald,MID,Man Utd,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-J.Fletcher,MID,Man Utd,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Kone,MID,Man Utd,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Moorhouse,MID,Man Utd,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Højlund,FWD,Man Utd,6.5,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Zirkzee,FWD,Man Utd,6.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Obi,FWD,Man Utd,4.5,2.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Wheatley,FWD,Man Utd,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Šeško,FWD,Man Utd,7.5,9.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,Arsenal (Away),1
-Pope,GKP,Newcastle,5.0,3.7,9.0,a,90,0,0,3,0,0,0,0.0,0.0,0.0,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,27.0,0.0,0.0,2.7,32,9,0,0,Liverpool (Away),1
-Gillespie,GKP,Newcastle,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Odysseas,GKP,Newcastle,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Hall,DEF,Newcastle,5.5,2.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Schär,DEF,Newcastle,5.5,2.7,8.0,a,90,0,0,0,0,0,0,0.03,0.04,0.07,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,13.8,1.9,4.0,2.0,26,8,0,0,Liverpool (Away),1
-Botman,DEF,Newcastle,5.0,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Burn,DEF,Newcastle,5.0,3.7,9.0,a,90,0,0,0,0,0,0,0.01,0.0,0.01,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,18.6,1.2,2.0,2.2,30,9,0,0,Liverpool (Away),1
-Livramento,DEF,Newcastle,5.0,3.7,9.0,a,90,0,0,0,0,0,0,0.03,0.0,0.03,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,18.0,25.4,4.0,4.7,33,9,0,0,Liverpool (Away),1
-Trippier,DEF,Newcastle,5.0,2.1,6.0,a,90,0,0,0,0,0,0,0.06,0.0,0.06,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,9.8,22.5,0.0,3.2,26,6,0,0,Liverpool (Away),1
-Krafth,DEF,Newcastle,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Lascelles,DEF,Newcastle,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-A.Murphy,DEF,Newcastle,4.0,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Ashby,DEF,Newcastle,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Pivas,DEF,Newcastle,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Targett,DEF,Newcastle,4.0,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Gordon,MID,Newcastle,7.5,1.8,3.0,a,90,0,0,0,0,0,0,0.03,0.55,0.58,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,5.4,13.0,41.0,5.9,4,3,0,0,Liverpool (Away),1
-Elanga,MID,Newcastle,7.0,8.3,3.0,a,77,0,0,0,0,0,0,0.06,0.57,0.63,0.17,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,8.6,29.8,27.0,6.5,10,3,0,0,Liverpool (Away),1
-Barnes,MID,Newcastle,6.5,0.6,3.0,a,89,0,0,0,0,0,0,0.33,0.23,0.56,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,12.8,56.8,25.0,9.5,15,3,0,0,Liverpool (Away),1
-Bruno G.,MID,Newcastle,6.5,1.7,3.0,a,90,0,0,0,0,0,0,0.1,0.0,0.1,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,7.6,22.6,2.0,3.2,11,3,0,0,Liverpool (Away),1
-J.Murphy,MID,Newcastle,6.5,2.4,1.0,a,12,0,0,0,0,0,0,0.01,0.0,0.01,0.03,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.6,1.3,4.0,0.6,3,1,0,0,Liverpool (Away),1
-Joelinton,MID,Newcastle,6.0,0.5,2.0,a,82,0,0,0,0,0,0,0.02,0.0,0.02,0.17,1,0,0,0,1,0,1,False,0.0,0.0,Aston Villa,4.4,4.2,6.0,1.5,7,2,0,0,Liverpool (Away),1
-Tonali,MID,Newcastle,5.5,1.9,3.0,a,90,0,0,0,0,0,0,0.18,0.0,0.18,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,13.8,29.2,0.0,4.3,20,3,0,0,Liverpool (Away),1
-Antoñito C.,MID,Newcastle,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Willock,MID,Newcastle,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Hayden,MID,Newcastle,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Kuol,MID,Newcastle,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-L.Miley,MID,Newcastle,4.5,2.7,1.0,a,7,0,0,0,0,0,0,0.01,0.0,0.01,0.03,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,2.6,11.0,2.0,1.6,4,1,0,0,Liverpool (Away),1
-White,MID,Newcastle,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Isak,FWD,Newcastle,10.5,7.2,0.0,n,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Osula,FWD,Newcastle,5.5,0.2,1.0,a,1,0,0,0,0,0,0,0.02,0.03,0.05,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.3,7.0,0.7,3,1,0,0,Liverpool (Away),1
-Neave,FWD,Newcastle,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Ramsdale,GKP,Newcastle,5.0,0.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Thiaw,DEF,Newcastle,5.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Seung soo,MID,Newcastle,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,Liverpool (Away),1
-Sels,GKP,Nott'm Forest,5.0,20.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-C.Miguel,GKP,Nott'm Forest,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Turner,GKP,Nott'm Forest,4.0,0.2,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Milenković,DEF,Nott'm Forest,5.5,10.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Murillo,DEF,Nott'm Forest,5.5,7.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Aina,DEF,Nott'm Forest,5.0,15.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-N.Williams,DEF,Nott'm Forest,5.0,10.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-David Carmo,DEF,Nott'm Forest,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Jair Cunha,DEF,Nott'm Forest,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Morato,DEF,Nott'm Forest,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-O.Richards,DEF,Nott'm Forest,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Abbott,DEF,Nott'm Forest,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Boly,DEF,Nott'm Forest,4.0,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Gibbs-White,MID,Nott'm Forest,7.5,5.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Hudson-Odoi,MID,Nott'm Forest,6.0,1.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Anderson,MID,Nott'm Forest,5.5,6.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Jota,MID,Nott'm Forest,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Dominguez,MID,Nott'm Forest,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-O'Brien,MID,Nott'm Forest,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Sangaré,MID,Nott'm Forest,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Yates,MID,Nott'm Forest,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Da Silva Moreira,MID,Nott'm Forest,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Stamenic,MID,Nott'm Forest,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Wood,FWD,Nott'm Forest,7.5,12.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Igor Jesus,FWD,Nott'm Forest,6.0,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Awoniyi,FWD,Nott'm Forest,5.5,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Ndoye,MID,Nott'm Forest,6.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Gunn,GKP,Nott'm Forest,4.0,1.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,,,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,Brentford (Away),1
-Marc Guiu,FWD,Sunderland,4.5,20.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Patterson,GKP,Sunderland,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Moore,GKP,Sunderland,4.0,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Nna Noukeu,GKP,Sunderland,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Ballard,DEF,Sunderland,4.5,0.9,17.0,a,90,1,0,0,0,1,0,0.01,0.19,0.2,0.61,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,70.4,0.5,64.0,13.5,54,17,0,0,Burnley (Home),1
-Hume,DEF,Sunderland,4.5,0.2,6.0,a,90,0,0,0,0,0,0,0.09,0.0,0.09,0.61,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,15.0,15.8,2.0,3.3,25,6,0,0,Burnley (Home),1
-Alese,DEF,Sunderland,4.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Anderson,DEF,Sunderland,4.0,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Cirkin,DEF,Sunderland,4.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Hjelde,DEF,Sunderland,4.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Huggins,DEF,Sunderland,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Johnson,DEF,Sunderland,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-O'Nien,DEF,Sunderland,4.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Pembele,DEF,Sunderland,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Reinildo,DEF,Sunderland,4.0,7.3,6.0,a,90,0,0,0,0,0,0,0.0,0.0,0.0,0.61,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,13.6,2.5,0.0,1.6,27,6,0,0,Burnley (Home),1
-Seelt,DEF,Sunderland,4.0,0.3,1.0,a,52,0,0,0,0,0,0,0.0,0.0,0.0,0.34,0,0,0,0,0,0,1,True,3.0,0.0,West Ham,15.0,0.6,0.0,1.6,6,1,0,0,Burnley (Home),1
-Adingra,MID,Sunderland,5.5,1.6,6.0,a,75,0,1,0,0,0,1,0.02,0.16,0.18,0.34,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,0.0,14.5,6.0,2.0,12,6,0,0,Burnley (Home),1
-Diarra,MID,Sunderland,5.5,0.1,3.0,a,90,0,0,0,0,0,0,0.01,0.21,0.22,0.61,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,7.0,1.8,20.0,2.9,4,3,0,0,Burnley (Home),1
-Roberts,MID,Sunderland,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Aleksić,MID,Sunderland,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-E.Le Fée,MID,Sunderland,5.0,0.4,1.0,a,14,0,0,0,0,0,0,0.0,0.0,0.0,0.27,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,3.2,0.3,0.0,0.4,4,1,0,0,Burnley (Home),1
-Mundle,MID,Sunderland,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Neil,MID,Sunderland,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Poveda,MID,Sunderland,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Rigg,MID,Sunderland,5.0,0.1,1.0,a,1,0,0,0,0,0,0,0.0,0.0,0.0,0.03,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,3,1,0,0,Burnley (Home),1
-Sadiki,MID,Sunderland,5.0,0.0,3.0,a,90,0,0,0,0,0,0,0.01,0.0,0.01,0.61,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,9.0,2.8,0.0,1.2,6,3,0,0,Burnley (Home),1
-Talbi,MID,Sunderland,5.0,0.2,6.0,a,90,0,1,0,0,0,1,0.01,0.0,0.01,0.58,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,20.8,17.4,2.0,4.0,17,6,0,0,Burnley (Home),1
-Ba,MID,Sunderland,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Browne,MID,Sunderland,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Ekwah,MID,Sunderland,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-H.Jones,MID,Sunderland,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Matete,MID,Sunderland,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Triantis,MID,Sunderland,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Isidor,FWD,Sunderland,5.5,0.2,5.0,a,14,1,0,0,0,1,0,0.0,0.04,0.04,0.27,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,34.2,0.1,17.0,5.1,29,5,0,0,Burnley (Home),1
-Mayenda,FWD,Sunderland,5.5,0.5,8.0,a,75,1,0,0,0,1,0,0.0,0.1,0.1,0.34,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,34.0,11.3,26.0,7.1,37,8,0,0,Burnley (Home),1
-Abdullahi,FWD,Sunderland,4.5,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Luís Hemir,FWD,Sunderland,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Rusyn,FWD,Sunderland,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Xhaka,MID,Sunderland,5.0,2.8,3.0,a,90,0,0,0,0,0,0,0.04,0.0,0.04,0.61,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,15.4,31.8,0.0,4.7,10,3,0,0,Burnley (Home),1
-Roefs,GKP,Sunderland,4.5,0.3,8.0,a,90,0,0,4,0,0,0,0.0,0.0,0.0,0.61,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,30.2,0.0,0.0,3.0,31,8,0,0,Burnley (Home),1
-Masuaku,DEF,Sunderland,4.0,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,Burnley (Home),1
-Alderete,DEF,Sunderland,4.0,0.9,4.0,a,37,0,1,0,0,0,1,0.12,0.0,0.12,0.27,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,29.0,14.4,0.0,4.3,15,4,0,0,Burnley (Home),1
-Vicario,GKP,Spurs,5.0,4.3,9.0,a,90,0,0,4,0,0,0,0.0,0.0,0.0,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,30.4,0.0,0.0,3.0,36,9,0,0,Man City (Home),1
-Austin,GKP,Spurs,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Kinsky,GKP,Spurs,4.0,2.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Pedro Porro,DEF,Spurs,5.5,22.7,6.0,a,90,0,0,0,0,0,0,0.26,0.02,0.28,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,21.2,42.8,1.0,6.5,26,6,0,0,Man City (Home),1
-Romero,DEF,Spurs,5.0,3.6,6.0,a,90,0,0,0,0,0,0,0.02,0.0,0.02,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,18.2,1.4,6.0,2.6,22,6,0,0,Man City (Home),1
-Danso,DEF,Spurs,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Davies,DEF,Spurs,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Dragusin,DEF,Spurs,4.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Spence,DEF,Spurs,4.5,1.3,6.0,a,90,0,0,0,0,0,0,0.07,0.18,0.25,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,10.0,5.8,22.0,3.8,26,6,0,0,Man City (Home),1
-Udogie,DEF,Spurs,4.5,0.8,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Van de Ven,DEF,Spurs,4.5,27.8,6.0,a,90,0,0,0,0,0,0,0.01,0.59,0.6,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,11.6,1.0,14.0,2.7,27,6,0,0,Man City (Home),1
-Phillips,DEF,Spurs,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Takai,DEF,Spurs,4.0,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Vuskovic,DEF,Spurs,4.0,1.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Son,MID,Spurs,8.5,0.3,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Johnson,MID,Spurs,7.0,3.1,8.0,a,79,1,0,0,0,1,0,0.06,0.5,0.56,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,40.4,27.1,20.0,8.8,30,8,0,0,Man City (Home),1
-Maddison,MID,Spurs,7.0,0.3,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Kudus,MID,Spurs,6.5,25.4,10.0,a,84,0,2,0,0,0,2,0.58,0.06,0.64,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,45.4,74.0,11.0,13.0,35,10,0,0,Man City (Home),1
-Kulusevski,MID,Spurs,6.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Tel,MID,Spurs,6.5,0.1,1.0,a,5,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.1,0.0,0.0,1,1,0,0,Man City (Home),1
-Bentancur,MID,Spurs,5.5,0.2,1.0,a,19,0,0,0,0,0,0,0.0,0.0,0.0,0.04,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,4.8,0.8,0.0,0.6,5,1,0,0,Man City (Home),1
-Bergvall,MID,Spurs,5.5,0.2,3.0,a,79,0,0,0,0,0,0,0.01,0.12,0.13,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,10.4,3.3,33.0,4.7,13,3,0,0,Man City (Home),1
-Bissouma,MID,Spurs,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Odobert,MID,Spurs,5.5,0.0,1.0,a,10,0,0,0,0,0,0,0.01,0.0,0.01,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,2.2,10.5,0.0,1.3,4,1,0,0,Man City (Home),1
-Solomon,MID,Spurs,5.5,0.0,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Bryan,MID,Spurs,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Gray,MID,Spurs,5.0,0.1,3.0,a,70,0,0,0,0,0,0,0.05,0.0,0.05,0.89,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,3.6,3.1,2.0,0.9,13,3,0,0,Man City (Home),1
-Moore,MID,Spurs,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-P.M.Sarr,MID,Spurs,5.0,2.8,6.0,a,90,0,1,0,0,0,1,0.22,0.0,0.22,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,33.2,18.7,2.0,5.4,29,6,0,0,Man City (Home),1
-Min-hyeok,MID,Spurs,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Olusesi,MID,Spurs,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Solanke,FWD,Spurs,7.5,4.7,1.0,a,19,0,0,0,0,0,0,0.0,0.08,0.08,0.04,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,2.0,0.3,6.0,0.8,5,1,0,0,Man City (Home),1
-Richarlison,FWD,Spurs,6.5,2.7,13.0,a,71,2,0,0,0,2,0,0.01,0.78,0.79,0.89,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,73.6,0.5,80.0,15.4,61,13,0,0,Man City (Home),1
-Lankshear,FWD,Spurs,4.5,0.1,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-Scarlett,FWD,Spurs,4.5,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,Man City (Home),1
-J.Palhinha,MID,Spurs,5.5,0.4,1.0,a,10,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.2,0.6,0.0,0.1,2,1,0,0,Man City (Home),1
-Areola,GKP,West Ham,4.5,4.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-Foderingham,GKP,West Ham,4.0,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-Hegyi,GKP,West Ham,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-Diouf,DEF,West Ham,4.5,7.7,1.0,a,90,0,0,0,3,0,0,0.07,0.18,0.25,0.7,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,8.8,27.7,10.0,4.7,2,1,0,0,Chelsea (Away),1
-Emerson,DEF,West Ham,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-Kilman,DEF,West Ham,4.5,0.3,0.0,a,90,0,0,0,3,0,0,0.03,0.0,0.03,0.7,0,0,0,0,1,0,1,False,3.0,0.0,Sunderland,27.8,16.2,0.0,4.4,6,0,0,0,Chelsea (Away),1
-Mavropanos,DEF,West Ham,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-N.Aguerd,DEF,West Ham,4.5,0.1,1.0,a,90,0,0,0,3,0,0,0.02,0.0,0.02,0.7,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,12.6,3.0,0.0,1.6,0,1,0,0,Chelsea (Away),1
-Scarles,DEF,West Ham,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-Todibo,DEF,West Ham,4.5,0.1,1.0,a,81,0,0,0,2,0,0,0.01,0.0,0.01,0.66,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,17.8,3.1,0.0,2.1,9,1,0,0,Chelsea (Away),1
-Wan-Bissaka,DEF,West Ham,4.5,25.1,1.0,a,90,0,0,0,3,0,0,0.07,0.0,0.07,0.7,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,17.8,24.7,8.0,5.1,9,1,0,0,Chelsea (Away),1
-Casey,DEF,West Ham,4.0,0.2,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-L.Paquetá,MID,West Ham,6.0,1.1,2.0,a,90,0,0,0,3,0,0,0.08,0.0,0.08,0.7,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,6.8,12.2,4.0,2.3,13,2,0,0,Chelsea (Away),1
-Souček,MID,West Ham,6.0,0.9,1.0,a,19,0,0,0,2,0,0,0.0,0.07,0.07,0.08,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,4.2,1.3,19.0,2.5,4,1,0,0,Chelsea (Away),1
-Ward-Prowse,MID,West Ham,6.0,0.4,2.0,a,70,0,0,0,1,0,0,0.02,0.0,0.02,0.62,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,6.8,15.2,2.0,2.4,13,2,0,0,Chelsea (Away),1
-Summerville,MID,West Ham,5.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-Álvarez,MID,West Ham,5.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-Cornet,MID,West Ham,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-G.Rodriguez,MID,West Ham,5.0,0.1,2.0,a,70,0,0,0,1,0,0,0.03,0.02,0.05,0.62,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,2.2,2.3,2.0,0.7,13,2,0,0,Chelsea (Away),1
-L.Guilherme,MID,West Ham,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-Earthy,MID,West Ham,4.5,0.1,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-Irving,MID,West Ham,4.5,0.3,1.0,a,8,0,0,0,1,0,0,0.06,0.0,0.06,0.04,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,4.4,14.8,0.0,1.9,6,1,0,0,Chelsea (Away),1
-Orford,MID,West Ham,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-Potts,MID,West Ham,4.5,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-Bowen,FWD,West Ham,8.0,16.8,2.0,a,90,0,0,0,3,0,0,0.05,0.19,0.24,0.7,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,10.6,4.3,34.0,4.9,13,2,0,0,Chelsea (Away),1
-Füllkrug,FWD,West Ham,6.0,3.7,2.0,a,90,0,0,0,3,0,0,0.08,0.13,0.21,0.7,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,0.8,14.5,34.0,4.9,-1,2,0,0,Chelsea (Away),1
-Marshall,FWD,West Ham,4.5,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-Walker-Peters,DEF,West Ham,4.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,Chelsea (Away),1
-Wilson,FWD,West Ham,6.0,0.5,1.0,a,19,0,0,0,2,0,0,0.0,0.02,0.02,0.08,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,8.0,0.5,2,1,0,0,Chelsea (Away),1
-Hermansen,GKP,West Ham,4.5,0.3,1.0,a,90,0,0,2,3,0,0,0.01,0.0,0.01,0.7,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,21.0,0.0,0.0,2.1,3,1,0,0,Chelsea (Away),1
-Johnstone,GKP,Wolves,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-José Sá,GKP,Wolves,4.5,2.1,0.0,a,90,0,0,0,4,0,0,0.0,0.0,0.0,2.44,0,0,0,0,0,0,1,True,0.0,4.0,Man City,3.6,0.0,0.0,0.4,-9,0,0,0,Bournemouth (Home),1
-Bentley,GKP,Wolves,4.0,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-King,GKP,Wolves,4.0,1.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Agbadou,DEF,Wolves,4.5,0.4,0.0,a,90,0,0,0,4,0,0,0.01,0.02,0.03,2.44,0,0,0,0,0,0,1,True,0.0,4.0,Man City,11.8,0.3,1.0,1.3,-7,0,0,0,Bournemouth (Home),1
-Doherty,DEF,Wolves,4.5,0.2,-1.0,a,90,0,0,0,4,0,0,0.01,0.0,0.01,2.44,0,0,0,0,1,0,1,True,0.0,4.0,Man City,9.8,5.9,0.0,1.6,-1,-1,0,0,Bournemouth (Home),1
-H.Bueno,DEF,Wolves,4.5,0.1,1.0,a,18,0,0,0,1,0,0,0.01,0.0,0.01,0.24,0,0,0,0,0,0,0,True,0.0,4.0,Man City,3.4,11.1,6.0,2.1,-1,1,0,0,Bournemouth (Home),1
-Mosquera,DEF,Wolves,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-R.Gomes,DEF,Wolves,4.5,0.1,1.0,a,17,0,0,0,1,0,0,0.0,0.0,0.0,0.24,0,0,0,0,0,0,0,True,0.0,4.0,Man City,2.2,1.0,4.0,0.7,-1,1,0,0,Bournemouth (Home),1
-S.Bueno,DEF,Wolves,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Toti,DEF,Wolves,4.5,0.2,0.0,a,90,0,0,0,4,0,0,0.0,0.0,0.0,2.44,0,0,0,0,0,0,1,True,0.0,4.0,Man City,14.8,10.8,0.0,2.6,0,0,0,0,Bournemouth (Home),1
-Hoever,DEF,Wolves,4.0,2.4,1.0,a,72,0,0,0,3,0,0,0.14,0.0,0.14,2.2,0,0,0,0,0,0,1,True,0.0,4.0,Man City,19.6,19.8,0.0,3.9,2,1,0,0,Bournemouth (Home),1
-Meupiyou,DEF,Wolves,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Pedro Lima,DEF,Wolves,4.0,1.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Pond,DEF,Wolves,4.0,1.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Hee Chan,MID,Wolves,6.0,0.2,1.0,a,8,0,0,0,0,0,0,0.02,0.0,0.02,0.18,0,0,0,0,0,0,0,True,0.0,4.0,Man City,3.0,10.3,0.0,1.3,3,1,0,0,Bournemouth (Home),1
-André,MID,Wolves,5.5,0.1,4.0,a,71,0,0,0,3,0,0,0.01,0.0,0.01,2.2,0,0,0,0,0,0,1,True,0.0,4.0,Man City,15.0,1.4,0.0,1.6,10,4,0,0,Bournemouth (Home),1
-Bellegarde,MID,Wolves,5.5,0.1,2.0,a,72,0,0,0,3,0,0,0.03,0.02,0.05,2.2,0,0,0,0,0,0,1,True,0.0,4.0,Man City,3.6,13.5,1.0,1.8,5,2,0,0,Bournemouth (Home),1
-Fer López,MID,Wolves,5.5,0.0,1.0,a,18,0,0,0,1,0,0,0.02,0.08,0.1,0.24,0,0,0,0,0,0,0,True,0.0,4.0,Man City,3.4,0.6,19.0,2.3,5,1,0,0,Bournemouth (Home),1
-Gomes,MID,Wolves,5.5,0.1,2.0,a,90,0,0,0,4,0,0,0.04,0.0,0.04,2.44,0,0,0,0,0,0,1,True,0.0,4.0,Man City,19.6,13.8,4.0,3.7,20,2,0,0,Bournemouth (Home),1
-Guedes,MID,Wolves,5.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Munetsi,MID,Wolves,5.5,0.0,2.0,a,90,0,0,0,4,0,0,0.02,0.05,0.07,2.44,0,0,0,0,0,0,1,True,0.0,4.0,Man City,7.4,6.5,7.0,2.1,9,2,0,0,Bournemouth (Home),1
-B.Traore,MID,Wolves,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Chirewa,MID,Wolves,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Edozie,MID,Wolves,4.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Gonzalez,MID,Wolves,4.5,1.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Hodge,MID,Wolves,4.5,0.1,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Strand Larsen,FWD,Wolves,6.5,4.9,2.0,a,81,0,0,0,4,0,0,0.01,0.31,0.32,2.25,0,0,0,0,0,0,1,True,0.0,4.0,Man City,11.0,2.4,45.0,5.8,8,2,0,0,Bournemouth (Home),1
-Fábio Silva,FWD,Wolves,5.0,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Kalajdžić,FWD,Wolves,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Chiwome,FWD,Wolves,4.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-Fraser,FWD,Wolves,4.5,2.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,Bournemouth (Home),1
-J.Arias,MID,Wolves,5.5,0.7,1.0,a,17,0,0,0,1,0,0,0.02,0.0,0.02,0.24,0,0,0,0,0,0,0,True,0.0,4.0,Man City,1.2,12.1,2.0,1.5,2,1,0,0,Bournemouth (Home),1
-Møller Wolfe,DEF,Wolves,4.5,0.1,1.0,a,71,0,0,0,3,0,0,0.0,0.0,0.0,2.2,0,0,0,0,0,0,1,True,0.0,4.0,Man City,7.2,0.8,2.0,1.0,-4,1,0,0,Bournemouth (Home),1
+Web name,Position,Team,Cost,Selected,Form,Status,Minutes,Goals,Assist,Saves,GC,Season Goals,Season Assists,xA,xG,xGI,xGC,CS,OGs,Pens Missed,Pens Saved,Yellow cards,Red cards,Starts,Was home,Team H Score,Team A Score,Opponent Team,Influence,Creativity,Threat,ICT Index,Bps,Bonus,GW Points,Transfers In,Transfers Out,Next Fixture,GW
+Raya,GKP,Arsenal,5.5,18.6,10.0,a,90,0,0,7,0,0,0,0.0,0.0,0.0,1.52,1,0,0,0,1,0,1,False,0.0,1.0,Man Utd,49.2,0.0,0.0,4.9,38,3,10,0,0,Leeds (Away),1
+Arrizabalaga,GKP,Arsenal,4.5,0.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Hein,GKP,Arsenal,4.0,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Setford,GKP,Arsenal,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Gabriel,DEF,Arsenal,6.0,19.1,6.0,a,90,0,0,0,0,0,0,0.0,0.0,0.0,1.52,1,0,0,0,0,0,1,False,0.0,1.0,Man Utd,22.8,0.3,4.0,2.7,23,0,6,0,0,Leeds (Away),1
+Saliba,DEF,Arsenal,6.0,15.3,9.0,a,90,0,0,0,0,0,0,0.0,0.0,0.0,1.52,1,0,0,0,0,0,1,False,0.0,1.0,Man Utd,31.4,0.1,0.0,3.2,25,1,9,0,0,Leeds (Away),1
+Calafiori,DEF,Arsenal,5.5,2.1,13.0,a,71,1,0,0,0,1,0,0.01,0.91,0.92,0.87,1,0,0,0,1,0,1,False,0.0,1.0,Man Utd,36.2,2.1,35.0,7.3,33,2,13,0,0,Leeds (Away),1
+J.Timber,DEF,Arsenal,5.5,2.2,0.0,a,19,0,0,0,0,0,0,0.0,0.0,0.0,0.66,0,0,0,0,1,0,0,False,0.0,1.0,Man Utd,3.0,0.3,0.0,0.3,-3,0,0,0,0,Leeds (Away),1
+Kiwior,DEF,Arsenal,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Lewis-Skelly,DEF,Arsenal,5.5,4.1,0.0,a,18,0,0,0,0,0,0,0.0,0.0,0.0,0.66,0,0,0,0,1,0,0,False,0.0,1.0,Man Utd,0.2,0.0,0.0,0.0,-1,0,0,0,0,Leeds (Away),1
+White,DEF,Arsenal,5.5,0.9,6.0,a,70,0,0,0,0,0,0,0.01,0.01,0.02,0.87,1,0,0,0,0,0,1,False,0.0,1.0,Man Utd,15.4,11.3,1.0,2.8,23,0,6,0,0,Leeds (Away),1
+Zinchenko,DEF,Arsenal,5.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Clarke,DEF,Arsenal,4.0,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Kacurri,DEF,Arsenal,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Nichols,DEF,Arsenal,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Saka,MID,Arsenal,10.0,16.8,3.0,a,90,0,0,0,0,0,0,0.09,0.15,0.24,1.52,1,0,0,0,0,0,1,False,0.0,1.0,Man Utd,12.0,16.4,7.0,3.5,7,0,3,0,0,Leeds (Away),1
+Ødegaard,MID,Arsenal,8.0,3.7,5.0,a,90,0,0,0,0,0,0,0.29,0.09,0.38,1.52,1,0,0,0,0,0,1,False,0.0,1.0,Man Utd,17.8,20.3,17.0,5.5,16,0,5,0,0,Leeds (Away),1
+Madueke,MID,Arsenal,7.0,1.1,1.0,a,30,0,0,0,0,0,0,0.02,0.0,0.02,0.82,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,1.6,10.7,2.0,1.4,2,0,1,0,0,Leeds (Away),1
+Martinelli,MID,Arsenal,7.0,1.5,1.0,a,59,0,0,0,0,0,0,0.01,0.02,0.03,0.7,0,0,0,0,0,0,1,False,0.0,1.0,Man Utd,6.2,10.3,21.0,3.8,8,0,1,0,0,Leeds (Away),1
+Trossard,MID,Arsenal,7.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Rice,MID,Arsenal,6.5,8.1,6.0,a,82,0,1,0,0,0,1,0.01,0.13,0.14,1.04,1,0,0,0,0,0,1,False,0.0,1.0,Man Utd,2.6,1.3,8.0,1.2,14,0,6,0,0,Leeds (Away),1
+Merino,MID,Arsenal,6.0,0.6,1.0,a,7,0,0,0,0,0,0,0.0,0.0,0.0,0.49,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,1.2,0.0,0.0,0.1,2,0,1,0,0,Leeds (Away),1
+Fábio Vieira,MID,Arsenal,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Nørgaard,MID,Arsenal,5.5,0.6,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Nwaneri,MID,Arsenal,5.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Zubimendi,MID,Arsenal,5.5,2.2,5.0,a,90,0,0,0,0,0,0,0.01,0.0,0.01,1.52,1,0,0,0,0,0,1,False,0.0,1.0,Man Utd,16.0,1.9,2.0,2.0,15,0,5,0,0,Leeds (Away),1
+Nelson,MID,Arsenal,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Kabia,MID,Arsenal,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Sambi,MID,Arsenal,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Havertz,FWD,Arsenal,7.5,1.3,1.0,a,30,0,0,0,0,0,0,0.01,0.0,0.01,0.82,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,2.8,0.8,2.0,0.6,4,0,1,0,0,Leeds (Away),1
+G.Jesus,FWD,Arsenal,6.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Mosquera,DEF,Arsenal,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,1.0,Man Utd,0.0,0.0,0.0,0.0,0,0,0,0,0,Leeds (Away),1
+Gyökeres,FWD,Arsenal,9.0,25.2,1.0,a,59,0,0,0,0,0,0,0.06,0.0,0.06,0.7,0,0,0,0,0,0,1,False,0.0,1.0,Man Utd,0.4,5.5,6.0,1.2,0,0,1,0,0,Leeds (Away),1
+Martinez,GKP,Aston Villa,5.0,0.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+M.Bizot,GKP,Aston Villa,4.5,0.8,7.0,a,90,0,0,3,0,0,0,0.0,0.0,0.0,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,19.6,0.0,0.0,2.0,29,0,7,0,0,Brentford (Home),1
+Gauci,GKP,Aston Villa,4.0,0.3,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Marschall,GKP,Aston Villa,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Cash,DEF,Aston Villa,4.5,3.5,8.0,a,90,0,0,0,0,0,0,0.0,0.0,0.0,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,37.6,1.1,2.0,4.1,25,0,8,0,0,Brentford (Home),1
+Digne,DEF,Aston Villa,4.5,2.1,6.0,a,90,0,0,0,0,0,0,0.01,0.0,0.01,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,11.6,5.8,0.0,1.7,22,0,6,0,0,Brentford (Home),1
+Konsa,DEF,Aston Villa,4.5,19.0,3.0,s,65,0,0,0,0,0,0,0.01,0.0,0.01,1.11,1,0,0,0,0,1,1,True,0.0,0.0,Newcastle,1.8,1.1,0.0,0.3,15,0,3,0,0,Brentford (Home),1
+Maatsen,DEF,Aston Villa,4.5,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Mings,DEF,Aston Villa,4.5,1.2,6.0,a,90,0,0,0,0,0,0,0.0,0.0,0.0,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,13.0,3.7,0.0,1.7,25,0,6,0,0,Brentford (Home),1
+Pau,DEF,Aston Villa,4.5,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+A.García,DEF,Aston Villa,4.0,0.3,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Alex Moreno,DEF,Aston Villa,4.0,9.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Bogarde,DEF,Aston Villa,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Sousa,DEF,Aston Villa,4.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Yasin,DEF,Aston Villa,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Rogers,MID,Aston Villa,7.0,9.7,3.0,a,90,0,0,0,0,0,0,0.05,0.0,0.05,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,7.2,20.1,4.0,3.1,7,0,3,0,0,Brentford (Home),1
+Tielemans,MID,Aston Villa,6.0,2.2,3.0,a,90,0,0,0,0,0,0,0.01,0.0,0.01,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,4.0,1.1,0.0,0.5,5,0,3,0,0,Brentford (Home),1
+Bailey,MID,Aston Villa,5.5,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Buendía,MID,Aston Villa,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Iling Jr,MID,Aston Villa,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+J.Ramsey,MID,Aston Villa,5.5,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Malen,MID,Aston Villa,5.5,1.6,1.0,a,6,0,0,0,0,0,0,0.0,0.03,0.03,0.1,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,3.0,0.0,17.0,2.0,4,0,1,0,0,Brentford (Home),1
+McGinn,MID,Aston Villa,5.5,0.7,3.0,a,83,0,0,0,0,0,0,0.09,0.0,0.09,1.33,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,5.0,19.3,6.0,3.0,10,0,3,0,0,Brentford (Home),1
+Barkley,MID,Aston Villa,5.0,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Barrenechea,MID,Aston Villa,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Dobbin,MID,Aston Villa,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Kamara,MID,Aston Villa,5.0,0.2,2.0,a,90,0,0,0,0,0,0,0.03,0.05,0.08,1.43,1,0,0,0,1,0,1,True,0.0,0.0,Newcastle,13.8,2.2,17.0,3.3,13,0,2,0,0,Brentford (Home),1
+Onana,MID,Aston Villa,5.0,1.8,5.0,a,90,0,0,0,0,0,0,0.01,0.0,0.01,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,19.4,3.0,0.0,2.2,19,0,5,0,0,Brentford (Home),1
+Broggio,MID,Aston Villa,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Dendoncker,MID,Aston Villa,4.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Jimoh-Aloba,MID,Aston Villa,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Young,MID,Aston Villa,4.5,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Watkins,FWD,Aston Villa,9.0,26.1,2.0,a,90,0,0,0,0,0,0,0.01,0.12,0.13,1.43,1,0,0,0,0,0,1,True,0.0,0.0,Newcastle,10.6,12.2,27.0,5.0,12,0,2,0,0,Brentford (Home),1
+Redmond,FWD,Aston Villa,4.5,0.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Guessand,MID,Aston Villa,6.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Wright,GKP,Aston Villa,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Newcastle,0.0,0.0,0.0,0.0,0,0,0,0,0,Brentford (Home),1
+Weiss,GKP,Burnley,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Green,GKP,Burnley,4.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Hladký,GKP,Burnley,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Roberts,DEF,Burnley,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Walker,DEF,Burnley,4.5,1.9,1.0,a,90,0,0,0,3,0,0,0.02,0.01,0.03,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,8.2,0.9,1.0,1.0,-3,0,1,0,0,Sunderland (Away),1
+Delcroix,DEF,Burnley,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Dodgson,DEF,Burnley,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Ekdal,DEF,Burnley,4.0,0.2,1.0,a,90,0,0,0,3,0,0,0.0,0.0,0.0,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,9.8,0.5,8.0,1.8,-5,0,1,0,0,Sunderland (Away),1
+Estève,DEF,Burnley,4.0,19.9,1.0,a,90,0,0,0,3,0,0,0.0,0.05,0.05,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,19.4,0.5,17.0,3.7,0,0,1,0,0,Sunderland (Away),1
+Hartman,DEF,Burnley,4.0,0.5,1.0,a,90,0,0,0,3,0,0,0.04,0.0,0.04,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,13.4,11.7,2.0,2.7,-2,0,1,0,0,Sunderland (Away),1
+Humphreys,DEF,Burnley,4.0,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Jordan,DEF,Burnley,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Lucas Pires,DEF,Burnley,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Sambo,DEF,Burnley,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Sonne,DEF,Burnley,4.0,0.1,1.0,a,73,0,0,0,3,0,0,0.08,0.03,0.11,2.09,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,4.6,15.9,6.0,2.7,-4,0,1,0,0,Sunderland (Away),1
+Tuanzebe,DEF,Burnley,4.0,2.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Worrall,DEF,Burnley,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Anthony,MID,Burnley,5.5,0.1,2.0,a,84,0,0,0,3,0,0,0.36,0.44,0.8,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,7.0,26.2,32.0,6.5,9,0,2,0,0,Sunderland (Away),1
+Benson,MID,Burnley,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Bruun Larsen,MID,Burnley,5.5,0.0,1.0,a,27,0,0,0,1,0,0,0.01,0.0,0.01,0.91,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,3.6,0.7,8.0,1.2,2,0,1,0,0,Sunderland (Away),1
+Boateng,MID,Burnley,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Churlinov,MID,Burnley,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Cullen,MID,Burnley,5.0,0.1,4.0,a,90,0,0,0,3,0,0,0.28,0.0,0.28,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,23.8,59.4,0.0,8.3,21,0,4,0,0,Sunderland (Away),1
+Edwards,MID,Burnley,5.0,0.1,1.0,a,5,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,3,0,1,0,0,Sunderland (Away),1
+Hannibal,MID,Burnley,5.0,0.1,2.0,a,62,0,0,0,2,0,0,0.01,0.03,0.04,1.41,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,0.0,1.7,5.0,0.6,8,0,2,0,0,Sunderland (Away),1
+Koleosho,MID,Burnley,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Laurent,MID,Burnley,5.0,0.0,2.0,a,62,0,0,0,2,0,0,0.13,0.11,0.24,1.41,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,10.6,11.2,20.0,4.2,11,0,2,0,0,Sunderland (Away),1
+Tchaouna,MID,Burnley,5.0,0.0,1.0,a,16,0,0,0,0,0,0,0.01,0.0,0.01,0.23,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,3.2,0.8,0.0,0.4,4,0,1,0,0,Sunderland (Away),1
+A.Ramsey,MID,Burnley,4.5,9.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Adewumi,MID,Burnley,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Banel,MID,Burnley,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Trésor,MID,Burnley,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Flemming,FWD,Burnley,5.5,0.2,1.0,a,16,0,0,0,0,0,0,0.0,0.0,0.0,0.23,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,3,0,1,0,0,Sunderland (Away),1
+Amdouni,FWD,Burnley,5.0,0.1,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Foster,FWD,Burnley,5.0,0.5,2.0,a,73,0,0,0,3,0,0,0.04,0.22,0.26,2.09,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,4.8,22.7,10.0,3.8,6,0,2,0,0,Sunderland (Away),1
+Barnes,FWD,Burnley,4.5,2.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Obafemi,FWD,Burnley,4.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Dúbravka,GKP,Burnley,4.0,34.6,2.0,a,90,0,0,3,3,0,0,0.0,0.0,0.0,2.32,0,0,0,0,0,0,1,False,3.0,0.0,Spurs,25.6,0.0,0.0,2.6,5,0,2,0,0,Sunderland (Away),1
+Ugochukwu,MID,Burnley,5.0,0.0,1.0,a,27,0,0,0,1,0,0,0.0,0.05,0.05,0.91,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.3,3.0,0.1,1,0,1,0,0,Sunderland (Away),1
+Broja,FWD,Burnley,5.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Spurs,0.0,0.0,0.0,0.0,0,0,0,0,0,Sunderland (Away),1
+Neto,GKP,Bournemouth,4.5,0.2,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Petrović,GKP,Bournemouth,4.5,3.4,2.0,a,90,0,0,6,4,0,0,0.0,0.0,0.0,2.21,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,47.8,0.0,0.0,4.8,10,0,2,0,0,Wolves (Away),1
+Dennis,GKP,Bournemouth,4.0,1.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+McKenna,GKP,Bournemouth,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Paulsen,GKP,Bournemouth,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Zabarnyi,DEF,Bournemouth,5.0,0.1,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Senesi,DEF,Bournemouth,4.5,1.0,2.0,a,90,0,0,0,4,0,0,0.05,0.0,0.05,2.21,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,26.6,14.6,2.0,4.3,1,0,2,0,0,Wolves (Away),1
+Smith,DEF,Bournemouth,4.5,0.4,1.0,a,89,0,0,0,3,0,0,0.08,0.0,0.08,2.1,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,12.2,10.5,4.0,2.7,2,0,1,0,0,Wolves (Away),1
+Truffert,DEF,Bournemouth,4.5,0.8,0.0,a,90,0,0,0,4,0,0,0.13,0.0,0.13,2.21,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,18.2,19.1,0.0,3.7,-1,0,0,0,0,Wolves (Away),1
+Akinmboni,DEF,Bournemouth,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Bevan,DEF,Bournemouth,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Hill,DEF,Bournemouth,4.0,0.8,1.0,a,1,0,0,0,1,0,0,0.0,0.0,0.0,0.11,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,3.0,0.1,0.0,0.3,0,0,1,0,0,Wolves (Away),1
+J.Araujo,DEF,Bournemouth,4.0,1.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Mepham,DEF,Bournemouth,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Soler,DEF,Bournemouth,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Kluivert,MID,Bournemouth,7.0,0.7,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Semenyo,MID,Bournemouth,7.1,10.9,15.0,a,90,2,0,0,4,2,0,0.02,0.91,0.93,2.21,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,66.4,1.3,32.0,10.0,42,3,15,0,0,Wolves (Away),1
+Tavernier,MID,Bournemouth,5.5,0.5,4.0,a,90,0,0,0,4,0,0,0.06,0.32,0.38,2.21,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,24.6,14.1,33.0,7.2,20,0,4,0,0,Wolves (Away),1
+Adams,MID,Bournemouth,5.0,0.3,4.0,a,90,0,0,0,3,0,0,0.1,0.0,0.1,2.1,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,21.6,1.7,4.0,2.7,11,0,4,0,0,Wolves (Away),1
+Brooks,MID,Bournemouth,5.0,0.2,4.0,a,83,0,1,0,2,0,1,0.19,0.19,0.38,1.9,0,0,0,0,1,0,1,False,4.0,2.0,Liverpool,27.2,40.3,18.0,8.6,23,0,4,0,0,Wolves (Away),1
+Christie,MID,Bournemouth,5.0,0.1,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Cook,MID,Bournemouth,5.0,0.0,0.0,s,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Philip,MID,Bournemouth,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Scott,MID,Bournemouth,5.0,0.1,2.0,a,73,0,0,0,2,0,0,0.0,0.0,0.0,1.81,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,2.0,2.1,2.0,0.6,7,0,2,0,0,Wolves (Away),1
+Sinisterra,MID,Bournemouth,5.0,0.0,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Faivre,MID,Bournemouth,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+H.Traorè,MID,Bournemouth,4.5,0.8,4.0,a,16,0,1,0,2,0,1,0.0,0.0,0.0,0.4,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,21.2,10.0,0.0,3.1,12,0,4,0,0,Wolves (Away),1
+Sadi,MID,Bournemouth,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Silcott-Duberry,MID,Bournemouth,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Winterburn,MID,Bournemouth,4.5,0.1,1.0,a,6,0,0,0,2,0,0,0.0,0.0,0.0,0.31,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,3,0,1,0,0,Wolves (Away),1
+Evanilson,FWD,Bournemouth,7.0,2.1,1.0,a,90,0,0,0,4,0,0,0.0,0.29,0.29,2.21,0,0,0,0,1,0,1,False,4.0,2.0,Liverpool,0.0,0.6,17.0,1.6,-1,0,1,0,0,Wolves (Away),1
+Enes Ünal,FWD,Bournemouth,5.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Adu-Adjei,FWD,Bournemouth,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+Kroupi.Jr,FWD,Bournemouth,4.5,1.1,1.0,a,1,0,0,0,1,0,0,0.0,0.0,0.0,0.11,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,2,0,1,0,0,Wolves (Away),1
+Diakité,DEF,Bournemouth,4.5,0.2,0.0,a,90,0,0,0,4,0,0,0.0,0.0,0.0,2.21,0,0,0,0,0,0,1,False,4.0,2.0,Liverpool,14.8,0.2,0.0,1.5,2,0,0,0,0,Wolves (Away),1
+Rees-Dottin,MID,Bournemouth,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Wolves (Away),1
+O.Dango,MID,Brentford,6.0,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,4.0,2.0,Liverpool,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Kelleher,GKP,Brentford,4.5,10.7,1.0,a,90,0,0,2,3,0,0,0.0,0.0,0.0,1.86,0,0,0,0,0,0,1,False,3.0,1.0,Nott'm Forest,11.8,0.0,0.0,1.2,4,0,1,0,0,Aston Villa (Away),1
+Balcombe,GKP,Brentford,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Cox,GKP,Brentford,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Eyestone,GKP,Brentford,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Valdimarsson,GKP,Brentford,4.0,1.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Collins,DEF,Brentford,5.0,1.7,0.0,a,90,0,0,0,3,0,0,0.0,0.02,0.02,1.86,0,0,0,0,1,0,1,False,3.0,1.0,Nott'm Forest,9.8,0.2,5.0,1.5,0,0,0,0,0,Aston Villa (Away),1
+Lewis-Potter,DEF,Brentford,5.0,0.4,1.0,a,68,0,0,0,3,0,0,0.0,0.12,0.12,1.86,0,0,0,0,0,0,1,False,3.0,1.0,Nott'm Forest,5.4,4.5,7.0,1.7,-8,0,1,0,0,Aston Villa (Away),1
+Ajer,DEF,Brentford,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Henry,DEF,Brentford,4.5,0.2,1.0,a,87,0,0,0,3,0,0,0.04,0.0,0.04,1.86,0,0,0,0,0,0,1,False,3.0,1.0,Nott'm Forest,8.6,11.5,6.0,2.6,1,0,1,0,0,Aston Villa (Away),1
+Kayode,DEF,Brentford,4.5,0.2,1.0,a,90,0,0,0,3,0,0,0.08,0.0,0.08,1.86,0,0,0,0,0,0,1,False,3.0,1.0,Nott'm Forest,17.8,20.5,0.0,3.8,3,0,1,0,0,Aston Villa (Away),1
+Pinnock,DEF,Brentford,4.5,0.2,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Roerslev,DEF,Brentford,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Van den Berg,DEF,Brentford,4.5,0.4,3.0,a,90,0,0,0,3,0,0,0.0,0.21,0.21,1.86,0,0,0,0,0,0,1,False,3.0,1.0,Nott'm Forest,34.4,0.6,24.0,5.9,6,0,3,0,0,Aston Villa (Away),1
+Arthur,DEF,Brentford,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Fredrick,DEF,Brentford,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Hickey,DEF,Brentford,4.0,0.5,0.0,a,2,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,1,0,0,False,3.0,1.0,Nott'm Forest,2.0,0.0,0.0,0.2,1,0,0,0,0,Aston Villa (Away),1
+Ji-soo,DEF,Brentford,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Meghoma,DEF,Brentford,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Schade,MID,Brentford,7.0,0.3,1.0,a,45,0,0,0,0,0,0,0.04,0.0,0.04,0.37,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,4.6,0.9,6.0,1.2,1,0,1,0,0,Aston Villa (Away),1
+Damsgaard,MID,Brentford,6.0,1.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Milambo,MID,Brentford,5.5,0.1,1.0,a,45,0,0,0,3,0,0,0.01,0.0,0.01,1.49,0,0,0,0,0,0,1,False,3.0,1.0,Nott'm Forest,4.0,1.8,0.0,0.6,5,0,1,0,0,Aston Villa (Away),1
+Carvalho,MID,Brentford,5.0,0.3,2.0,a,90,0,0,0,3,0,0,0.03,0.03,0.06,1.86,0,0,0,0,0,0,1,False,3.0,1.0,Nott'm Forest,5.4,5.0,3.0,1.3,7,0,2,0,0,Aston Villa (Away),1
+Henderson,MID,Brentford,5.0,0.3,1.0,a,21,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,1.1,0.0,0.1,2,0,1,0,0,Aston Villa (Away),1
+Janelt,MID,Brentford,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Jensen,MID,Brentford,5.0,0.1,2.0,a,68,0,0,0,3,0,0,0.03,0.13,0.16,1.86,0,0,0,0,0,0,1,False,3.0,1.0,Nott'm Forest,9.0,25.4,8.0,4.2,10,0,2,0,0,Aston Villa (Away),1
+Nunes,MID,Brentford,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Onyeka,MID,Brentford,5.0,0.1,4.0,a,21,0,1,0,0,0,1,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.1,2.0,0.1,9,0,4,0,0,Aston Villa (Away),1
+Yarmoliuk,MID,Brentford,5.0,0.0,2.0,a,90,0,0,0,3,0,0,0.01,0.08,0.09,1.86,0,0,0,0,0,0,1,False,3.0,1.0,Nott'm Forest,3.6,10.8,7.0,2.1,10,0,2,0,0,Aston Villa (Away),1
+Donovan,MID,Brentford,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Konak,MID,Brentford,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Maghoma,MID,Brentford,4.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Peart-Harris,MID,Brentford,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Trevitt,MID,Brentford,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Wissa,FWD,Brentford,7.5,2.1,0.0,n,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Thiago,FWD,Brentford,6.0,0.9,6.0,a,90,1,0,0,3,1,0,0.01,0.91,0.92,1.86,0,0,0,0,0,0,1,False,3.0,1.0,Nott'm Forest,36.4,10.7,22.0,6.9,17,0,6,0,0,Aston Villa (Away),1
+Morgan,FWD,Brentford,4.5,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,1.0,Nott'm Forest,0.0,0.0,0.0,0.0,0,0,0,0,0,Aston Villa (Away),1
+Steele,GKP,Brighton,4.5,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Verbruggen,GKP,Brighton,4.5,7.7,2.0,a,90,0,0,1,1,0,0,0.0,0.0,0.0,0.76,0,0,0,0,0,0,1,True,1.0,1.0,Fulham,14.4,0.0,0.0,1.4,9,0,2,0,0,Everton (Home),1
+McGill,GKP,Brighton,4.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Rushworth,GKP,Brighton,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Scherpen,GKP,Brighton,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Boscagli,DEF,Brighton,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Coppola,DEF,Brighton,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+De Cuyper,DEF,Brighton,4.5,6.3,2.0,a,90,0,0,0,1,0,0,0.09,0.0,0.09,0.76,0,0,0,0,0,0,1,True,1.0,1.0,Fulham,15.0,26.7,4.0,4.6,8,0,2,0,0,Everton (Home),1
+Dunk,DEF,Brighton,4.5,1.3,2.0,a,90,0,0,0,1,0,0,0.0,0.09,0.09,0.76,0,0,0,0,0,0,1,True,1.0,1.0,Fulham,16.6,1.8,7.0,2.5,16,0,2,0,0,Everton (Home),1
+Estupiñan,DEF,Brighton,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+F.Kadıoğlu,DEF,Brighton,4.5,0.2,0.0,a,21,0,0,0,1,0,0,0.0,0.0,0.0,0.24,0,0,0,0,1,0,0,True,1.0,1.0,Fulham,0.0,1.3,0.0,0.1,-5,0,0,0,0,Everton (Home),1
+Igor,DEF,Brighton,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Lamptey,DEF,Brighton,4.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Van Hecke,DEF,Brighton,4.5,1.2,2.0,a,90,0,0,0,1,0,0,0.13,0.0,0.13,0.76,0,0,0,0,0,0,1,True,1.0,1.0,Fulham,28.0,1.3,0.0,2.9,15,0,2,0,0,Everton (Home),1
+Veltman,DEF,Brighton,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Webster,DEF,Brighton,4.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Cashin,DEF,Brighton,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Slater,DEF,Brighton,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Tasker,DEF,Brighton,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Mitoma,MID,Brighton,6.5,6.7,2.0,a,82,0,0,0,0,0,0,0.04,0.07,0.11,0.52,1,0,0,0,1,0,1,True,1.0,1.0,Fulham,0.0,2.4,8.0,0.6,-2,0,2,0,0,Everton (Home),1
+Georginio,MID,Brighton,6.0,1.4,6.0,a,68,0,1,0,0,0,1,0.0,0.07,0.07,0.52,1,0,0,0,0,0,1,True,1.0,1.0,Fulham,2.2,1.2,15.0,1.8,15,0,6,0,0,Everton (Home),1
+March,MID,Brighton,6.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Minteh,MID,Brighton,6.0,1.1,3.0,a,68,0,0,0,0,0,0,0.02,0.09,0.11,0.52,1,0,0,0,0,0,1,True,1.0,1.0,Fulham,0.4,2.9,12.0,1.5,7,0,3,0,0,Everton (Home),1
+Enciso,MID,Brighton,5.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Gruda,MID,Brighton,5.5,0.0,1.0,a,7,0,0,0,1,0,0,0.0,0.31,0.31,0.24,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.2,0.3,4.0,0.5,-2,0,1,0,0,Everton (Home),1
+Hinshelwood,MID,Brighton,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+O'Riley,MID,Brighton,5.5,1.0,10.0,a,87,1,0,0,0,1,0,0.14,0.79,0.93,0.52,1,0,0,0,0,0,1,True,1.0,1.0,Fulham,45.8,44.3,25.0,11.5,24,2,10,0,0,Everton (Home),1
+Sima,MID,Brighton,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Ayari,MID,Brighton,5.0,0.2,3.0,a,90,0,0,0,1,0,0,0.12,0.0,0.12,0.76,0,0,0,0,0,0,1,True,1.0,1.0,Fulham,7.2,3.2,2.0,1.2,20,1,3,0,0,Everton (Home),1
+Baleba,MID,Brighton,5.0,4.7,3.0,a,68,0,0,0,0,0,0,0.01,0.02,0.03,0.52,1,0,0,0,0,0,1,True,1.0,1.0,Fulham,4.0,11.9,1.0,1.7,10,0,3,0,0,Everton (Home),1
+Buonanotte,MID,Brighton,5.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Gomez,MID,Brighton,5.0,0.1,0.0,a,21,0,0,0,1,0,0,0.03,0.03,0.06,0.24,0,0,0,0,1,0,0,True,1.0,1.0,Fulham,7.6,11.3,7.0,2.6,7,0,0,0,0,Everton (Home),1
+Milner,MID,Brighton,5.0,0.1,1.0,a,2,0,0,0,1,0,0,0.0,0.0,0.0,0.24,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.1,0.0,0.0,3,0,1,0,0,Everton (Home),1
+Sarmiento,MID,Brighton,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Watson,MID,Brighton,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Wieffer,MID,Brighton,5.0,0.1,4.0,a,90,0,0,0,1,0,0,0.02,0.02,0.04,0.76,0,0,0,0,0,0,1,True,1.0,1.0,Fulham,24.8,2.8,21.0,4.9,17,0,4,0,0,Everton (Home),1
+Yalcouye,MID,Brighton,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Knight,MID,Brighton,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Mazilu,MID,Brighton,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Moran,MID,Brighton,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Welbeck,FWD,Brighton,6.5,4.1,1.0,a,21,0,0,0,1,0,0,0.0,0.0,0.0,0.24,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,2.2,0.6,2.0,0.5,3,0,1,0,0,Everton (Home),1
+Ferguson,FWD,Brighton,5.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Tzimas,FWD,Brighton,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Kostoulas,FWD,Brighton,5.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,1.0,Fulham,0.0,0.0,0.0,0.0,0,0,0,0,0,Everton (Home),1
+Sánchez,GKP,Chelsea,5.0,25.3,8.0,a,90,0,0,4,0,0,0,0.0,0.0,0.0,0.66,1,0,0,0,0,0,1,True,0.0,0.0,Crystal Palace,24.4,0.0,0.0,2.4,31,1,8,0,0,West Ham (Home),1
+Jörgensen,GKP,Chelsea,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Penders,GKP,Chelsea,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Slonina,GKP,Chelsea,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Cucurella,DEF,Chelsea,6.0,20.0,8.0,a,90,0,0,0,0,0,0,0.1,0.11,0.21,0.66,1,0,0,0,0,0,1,True,0.0,0.0,Crystal Palace,11.6,15.8,13.0,4.0,34,2,8,0,0,West Ham (Home),1
+James,DEF,Chelsea,5.5,5.7,5.0,a,78,0,0,0,0,0,0,0.19,0.0,0.19,0.61,1,0,0,0,1,0,1,True,0.0,0.0,Crystal Palace,17.0,46.6,0.0,6.4,29,0,5,0,0,West Ham (Home),1
+Chalobah,DEF,Chelsea,5.0,1.2,6.0,a,90,0,0,0,0,0,0,0.03,0.09,0.12,0.66,1,0,0,0,0,0,1,True,0.0,0.0,Crystal Palace,21.4,4.9,4.0,3.0,25,0,6,0,0,West Ham (Home),1
+Colwill,DEF,Chelsea,5.0,0.3,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Gusto,DEF,Chelsea,5.0,1.7,1.0,a,11,0,0,0,0,0,0,0.0,0.02,0.02,0.05,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,1.3,1.0,0.2,2,0,1,0,0,West Ham (Home),1
+B.Badiashile,DEF,Chelsea,4.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Fofana,DEF,Chelsea,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+M.Sarr,DEF,Chelsea,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Tosin,DEF,Chelsea,4.5,1.2,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Acheampong,DEF,Chelsea,4.0,1.2,9.0,a,90,0,0,0,0,0,0,0.01,0.09,0.1,0.66,1,0,0,0,0,0,1,True,0.0,0.0,Crystal Palace,16.2,2.3,10.0,2.9,35,3,9,0,0,West Ham (Home),1
+Anselmino,DEF,Chelsea,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Palmer,MID,Chelsea,10.5,61.0,3.0,a,90,0,0,0,0,0,0,0.03,0.17,0.2,0.66,1,0,0,0,0,0,1,True,0.0,0.0,Crystal Palace,4.8,16.9,23.0,4.5,10,0,3,0,0,West Ham (Home),1
+Neto,MID,Chelsea,7.0,3.7,3.0,a,90,0,0,0,0,0,0,0.36,0.03,0.39,0.66,1,0,0,0,0,0,1,True,0.0,0.0,Crystal Palace,13.8,37.7,10.0,6.2,18,0,3,0,0,West Ham (Home),1
+Enzo,MID,Chelsea,6.5,3.5,3.0,a,78,0,0,0,0,0,0,0.1,0.0,0.1,0.61,1,0,0,0,0,0,1,True,0.0,0.0,Crystal Palace,3.6,16.5,2.0,2.2,11,0,3,0,0,West Ham (Home),1
+Estêvão,MID,Chelsea,6.5,1.6,0.0,a,36,0,0,0,0,0,0,0.37,0.34,0.71,0.07,0,0,0,0,1,0,0,True,0.0,0.0,Crystal Palace,1.2,4.9,8.0,1.4,-3,0,0,0,0,West Ham (Home),1
+Gittens,MID,Chelsea,6.5,0.3,1.0,a,53,0,0,0,0,0,0,0.07,0.07,0.14,0.59,0,0,0,0,0,0,1,True,0.0,0.0,Crystal Palace,7.2,22.8,8.0,3.8,2,0,1,0,0,West Ham (Home),1
+Nkunku,MID,Chelsea,6.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Caicedo,MID,Chelsea,5.5,5.4,5.0,a,90,0,0,0,0,0,0,0.04,0.04,0.08,0.66,1,0,0,0,0,0,1,True,0.0,0.0,Crystal Palace,31.2,3.9,2.0,3.7,18,0,5,0,0,West Ham (Home),1
+George,MID,Chelsea,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Lavia,MID,Chelsea,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Mudryk,MID,Chelsea,5.0,0.0,0.0,s,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Andrey Santos,MID,Chelsea,4.5,0.3,1.0,a,11,0,0,0,0,0,0,0.0,0.31,0.31,0.05,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.4,0.3,21.0,2.2,1,0,1,0,0,West Ham (Home),1
+D.Essugo,MID,Chelsea,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Paez,MID,Chelsea,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+João Pedro,FWD,Chelsea,7.5,53.7,2.0,a,72,0,0,0,0,0,0,0.02,0.28,0.3,0.6,1,0,0,0,0,0,1,True,0.0,0.0,Crystal Palace,0.0,5.1,16.0,1.9,3,0,2,0,0,West Ham (Home),1
+Delap,FWD,Chelsea,6.5,3.9,1.0,a,17,0,0,0,0,0,0,0.01,0.05,0.06,0.05,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,5.4,1.3,19.0,2.6,4,0,1,0,0,West Ham (Home),1
+N.Jackson,FWD,Chelsea,6.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Hato,DEF,Chelsea,5.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,0.0,Crystal Palace,0.0,0.0,0.0,0.0,0,0,0,0,0,West Ham (Home),1
+Henderson,GKP,Crystal Palace,5.0,7.2,6.0,a,90,0,0,2,0,0,0,0.0,0.0,0.0,1.6,1,0,0,0,0,0,1,False,0.0,0.0,Chelsea,22.4,10.0,0.0,3.2,27,0,6,0,0,Nott'm Forest (Away),1
+Benitez,GKP,Crystal Palace,4.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Matthews,GKP,Crystal Palace,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Muñoz,DEF,Crystal Palace,5.5,8.6,5.0,a,90,0,0,0,0,0,0,0.0,0.05,0.05,1.6,1,0,0,0,1,0,1,False,0.0,0.0,Chelsea,10.0,0.4,6.0,1.6,17,0,5,0,0,Nott'm Forest (Away),1
+Lacroix,DEF,Crystal Palace,5.0,1.2,8.0,a,90,0,0,0,0,0,0,0.0,0.0,0.0,1.6,1,0,0,0,0,0,1,False,0.0,0.0,Chelsea,30.8,0.1,0.0,3.1,25,0,8,0,0,Nott'm Forest (Away),1
+Mitchell,DEF,Crystal Palace,5.0,1.4,9.0,a,90,0,0,0,0,0,0,0.0,0.0,0.0,1.6,1,0,0,0,0,0,1,False,0.0,0.0,Chelsea,26.0,0.3,0.0,2.6,31,1,9,0,0,Nott'm Forest (Away),1
+Sosa,DEF,Crystal Palace,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Guéhi,DEF,Crystal Palace,4.5,13.0,6.0,a,90,0,0,0,0,0,0,0.0,0.0,0.0,1.6,1,0,0,0,0,0,1,False,0.0,0.0,Chelsea,13.8,10.0,2.0,2.6,22,0,6,0,0,Nott'm Forest (Away),1
+Richards,DEF,Crystal Palace,4.5,1.5,6.0,a,90,0,0,0,0,0,0,0.01,0.08,0.09,1.6,1,0,0,0,0,0,1,False,0.0,0.0,Chelsea,21.8,0.0,4.0,2.6,24,0,6,0,0,Nott'm Forest (Away),1
+Chadi Riad,DEF,Crystal Palace,4.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Clyne,DEF,Crystal Palace,4.0,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Holding,DEF,Crystal Palace,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Kporha,DEF,Crystal Palace,4.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Eze,MID,Crystal Palace,7.5,10.9,3.0,a,83,0,0,0,0,0,0,0.0,0.24,0.24,1.22,1,0,0,0,0,0,1,False,0.0,0.0,Chelsea,7.2,2.6,26.0,3.6,10,0,3,0,0,Nott'm Forest (Away),1
+Sarr,MID,Crystal Palace,6.5,4.9,3.0,a,90,0,0,0,0,0,0,0.01,0.0,0.01,1.6,1,0,0,0,0,0,1,False,0.0,0.0,Chelsea,10.0,15.5,0.0,2.6,16,0,3,0,0,Nott'm Forest (Away),1
+Doucouré,MID,Crystal Palace,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Esse,MID,Crystal Palace,5.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Hughes,MID,Crystal Palace,5.0,0.1,2.0,a,69,0,0,0,0,0,0,0.0,0.0,0.0,1.22,1,0,0,0,1,0,1,False,0.0,0.0,Chelsea,14.4,0.1,0.0,1.5,7,0,2,0,0,Nott'm Forest (Away),1
+Kamada,MID,Crystal Palace,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Lerma,MID,Crystal Palace,5.0,0.1,1.0,a,20,0,0,0,0,0,0,0.0,0.0,0.0,0.38,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,1.0,1.0,2.0,0.4,3,0,1,0,0,Nott'm Forest (Away),1
+Wharton,MID,Crystal Palace,5.0,0.6,3.0,a,90,0,0,0,0,0,0,0.05,0.0,0.05,1.6,1,0,0,0,0,0,1,False,0.0,0.0,Chelsea,14.6,22.3,0.0,3.7,14,0,3,0,0,Nott'm Forest (Away),1
+Agbinone,MID,Crystal Palace,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Ahamada,MID,Crystal Palace,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Devenny,MID,Crystal Palace,4.5,1.8,1.0,a,6,0,0,0,0,0,0,0.0,0.0,0.0,0.38,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,3.0,0.0,2.0,0.5,5,0,1,0,0,Nott'm Forest (Away),1
+Ebiowei,MID,Crystal Palace,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+J.Rak-Sakyi,MID,Crystal Palace,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+M.França,MID,Crystal Palace,4.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Ozoh,MID,Crystal Palace,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Rodney,MID,Crystal Palace,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Umeh,MID,Crystal Palace,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Mateta,FWD,Crystal Palace,7.5,9.0,1.0,a,90,0,0,0,0,0,0,0.0,0.29,0.29,1.6,1,0,0,0,1,0,1,False,0.0,0.0,Chelsea,16.0,0.8,26.0,4.3,7,0,1,0,0,Nott'm Forest (Away),1
+Nketiah,FWD,Crystal Palace,5.5,0.3,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Édouard,FWD,Crystal Palace,5.0,0.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Marsh,FWD,Crystal Palace,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Cardines,MID,Crystal Palace,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Chelsea,0.0,0.0,0.0,0.0,0,0,0,0,0,Nott'm Forest (Away),1
+Dewsbury-Hall,MID,Everton,5.0,4.6,2.0,a,90,0,0,0,1,0,0,0.24,0.0,0.24,2.07,0,0,0,0,0,0,1,False,1.0,0.0,Leeds,12.6,27.4,2.0,4.2,15,0,2,0,0,Brighton (Away),1
+Pickford,GKP,Everton,5.5,11.2,2.0,a,90,0,0,2,1,0,0,0.0,0.0,0.0,2.07,0,0,0,0,0,0,1,False,1.0,0.0,Leeds,21.2,0.0,0.0,2.1,12,0,2,0,0,Brighton (Away),1
+Travers,GKP,Everton,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Tyrer,GKP,Everton,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Branthwaite,DEF,Everton,5.5,0.6,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Tarkowski,DEF,Everton,5.5,7.1,4.0,a,90,0,0,0,1,0,0,0.01,0.2,0.21,2.07,0,0,0,0,0,0,1,False,1.0,0.0,Leeds,31.0,2.1,7.0,4.0,7,0,4,0,0,Brighton (Away),1
+Mykolenko,DEF,Everton,5.0,0.8,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+O'Brien,DEF,Everton,5.0,0.6,2.0,a,90,0,0,0,1,0,0,0.01,0.17,0.18,2.07,0,0,0,0,0,0,1,False,1.0,0.0,Leeds,4.2,1.0,7.0,1.2,0,0,2,0,0,Brighton (Away),1
+Coleman,DEF,Everton,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Keane,DEF,Everton,4.5,0.4,2.0,a,90,0,0,0,1,0,0,0.0,0.0,0.0,2.07,0,0,0,0,0,0,1,False,1.0,0.0,Leeds,19.8,0.4,4.0,2.4,10,0,2,0,0,Brighton (Away),1
+Patterson,DEF,Everton,4.5,0.0,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Dixon,DEF,Everton,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Welch,DEF,Everton,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Ndiaye,MID,Everton,6.5,11.1,2.0,a,90,0,0,0,1,0,0,0.02,0.0,0.02,2.07,0,0,0,0,0,0,1,False,1.0,0.0,Leeds,12.6,12.1,2.0,2.7,11,0,2,0,0,Brighton (Away),1
+McNeil,MID,Everton,6.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Alcaraz,MID,Everton,5.5,0.2,1.0,a,85,0,0,0,1,0,0,0.01,0.03,0.04,1.87,0,0,0,0,1,0,1,False,1.0,0.0,Leeds,7.6,2.4,21.0,3.1,8,0,1,0,0,Brighton (Away),1
+Gana,MID,Everton,5.5,0.1,2.0,a,90,0,0,0,1,0,0,0.12,0.06,0.18,2.07,0,0,0,0,0,0,1,False,1.0,0.0,Leeds,7.2,19.6,3.0,3.0,12,0,2,0,0,Brighton (Away),1
+Garner,MID,Everton,5.0,0.1,2.0,a,90,0,0,0,1,0,0,0.01,0.03,0.04,2.07,0,0,0,0,0,0,1,False,1.0,0.0,Leeds,16.4,3.2,2.0,2.2,16,0,2,0,0,Brighton (Away),1
+Iroegbunam,MID,Everton,5.0,0.0,2.0,a,70,0,0,0,0,0,0,0.0,0.0,0.0,0.93,1,0,0,0,1,0,1,False,1.0,0.0,Leeds,12.0,1.1,0.0,1.3,5,0,2,0,0,Brighton (Away),1
+Armstrong,MID,Everton,4.5,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Bates,MID,Everton,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Ebere,MID,Everton,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Heath,MID,Everton,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Metcalfe,MID,Everton,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Barry,FWD,Everton,6.0,0.7,1.0,a,4,0,0,0,0,0,0,0.0,0.0,0.0,0.2,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,1.0,2.0,0.3,3,0,1,0,0,Brighton (Away),1
+Beto,FWD,Everton,5.5,8.3,2.0,a,90,0,0,0,1,0,0,0.01,0.06,0.07,2.07,0,0,0,0,0,0,1,False,1.0,0.0,Leeds,10.2,2.8,7.0,2.0,7,0,2,0,0,Brighton (Away),1
+Y.Chermiti,FWD,Everton,5.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Sherif,FWD,Everton,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Grealish,MID,Everton,6.5,3.6,1.0,a,19,0,0,0,1,0,0,0.0,0.02,0.02,1.14,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,5.8,0.8,5.0,1.2,4,0,1,0,0,Brighton (Away),1
+King,GKP,Everton,4.0,1.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Aznou,DEF,Everton,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,0.0,Leeds,0.0,0.0,0.0,0.0,0,0,0,0,0,Brighton (Away),1
+Leno,GKP,Fulham,5.0,1.6,3.0,a,90,0,0,3,1,0,0,0.0,0.0,0.0,1.48,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,23.6,0.0,0.0,2.4,15,0,3,0,0,Man Utd (Away),1
+Benda,GKP,Fulham,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,0,Man Utd (Away),1
+Robinson,DEF,Fulham,5.0,0.8,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,0,Man Utd (Away),1
+Andersen,DEF,Fulham,4.5,3.0,2.0,a,90,0,0,0,1,0,0,0.01,0.0,0.01,1.48,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,16.4,1.0,4.0,2.1,14,0,2,0,0,Man Utd (Away),1
+Bassey,DEF,Fulham,4.5,0.5,1.0,a,90,0,0,0,1,0,0,0.01,0.0,0.01,1.48,0,0,0,0,1,0,1,False,1.0,1.0,Brighton,12.4,1.6,0.0,1.4,3,0,1,0,0,Man Utd (Away),1
+Castagne,DEF,Fulham,4.5,0.1,1.0,a,6,0,0,0,0,0,0,0.0,0.0,0.0,0.4,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.2,0.7,2.0,0.3,3,0,1,0,0,Man Utd (Away),1
+Diop,DEF,Fulham,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,0,Man Utd (Away),1
+J.Cuenca,DEF,Fulham,4.5,0.0,2.0,a,83,0,0,0,1,0,0,0.01,0.0,0.01,1.07,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,9.6,1.2,4.0,1.5,10,0,2,0,0,Man Utd (Away),1
+Tete,DEF,Fulham,4.5,0.2,2.0,a,90,0,0,0,1,0,0,0.01,0.0,0.01,1.48,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,13.0,1.7,0.0,1.5,17,0,2,0,0,Man Utd (Away),1
+Amissah,DEF,Fulham,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,0,Man Utd (Away),1
+Iwobi,MID,Fulham,6.5,1.5,2.0,a,65,0,0,0,1,0,0,0.28,0.01,0.29,1.05,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,9.6,40.5,1.0,5.1,10,0,2,0,0,Man Utd (Away),1
+Smith Rowe,MID,Fulham,6.0,0.9,1.0,a,13,0,0,0,0,0,0,0.0,0.09,0.09,0.4,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.2,2.0,2.0,0.4,2,0,1,0,0,Man Utd (Away),1
+Adama,MID,Fulham,5.5,0.3,1.0,a,24,0,0,0,0,0,0,0.0,0.0,0.0,0.43,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.8,0.0,0.0,1,0,1,0,0,Man Utd (Away),1
+Andreas,MID,Fulham,5.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,0,Man Utd (Away),1
+Sessegnon,MID,Fulham,5.5,0.0,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,0,Man Utd (Away),1
+Wilson,MID,Fulham,5.5,1.0,5.0,a,90,0,1,0,1,0,1,0.02,0.07,0.09,1.48,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,3.0,5.4,13.0,2.1,16,0,5,0,0,Man Utd (Away),1
+Berge,MID,Fulham,5.0,0.1,2.0,a,65,0,0,0,1,0,0,0.01,0.0,0.01,1.05,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,1.2,0.7,0.0,0.2,3,0,2,0,0,Man Utd (Away),1
+Cairney,MID,Fulham,5.0,0.0,0.0,a,24,0,0,0,0,0,0,0.0,0.0,0.0,0.43,0,0,0,0,1,0,0,False,1.0,1.0,Brighton,0.0,0.4,0.0,0.0,-3,0,0,0,0,Man Utd (Away),1
+Lukić,MID,Fulham,5.0,0.1,2.0,a,90,0,0,0,1,0,0,0.01,0.0,0.01,1.48,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,1.8,13.3,2.0,1.7,9,0,2,0,0,Man Utd (Away),1
+Godo,MID,Fulham,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,0,Man Utd (Away),1
+Harris,MID,Fulham,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,0,Man Utd (Away),1
+King,MID,Fulham,4.5,1.0,2.0,a,76,0,0,0,1,0,0,0.13,0.18,0.31,1.07,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,12.4,14.0,27.0,5.3,11,0,2,0,0,Man Utd (Away),1
+Reed,MID,Fulham,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,0,Man Utd (Away),1
+Raúl,FWD,Fulham,6.5,2.1,2.0,a,65,0,0,0,1,0,0,0.0,0.29,0.29,1.05,0,0,0,0,0,0,1,False,1.0,1.0,Brighton,0.0,3.3,11.0,0.7,0,0,2,0,0,Man Utd (Away),1
+Muniz,FWD,Fulham,5.5,2.2,7.0,a,24,1,0,0,0,1,0,0.0,0.15,0.15,0.43,0,0,0,0,1,0,0,False,1.0,1.0,Brighton,31.0,0.0,33.0,6.4,25,3,7,0,0,Man Utd (Away),1
+Lecomte,GKP,Fulham,4.0,0.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,1.0,1.0,Brighton,0.0,0.0,0.0,0.0,0,0,0,0,0,Man Utd (Away),1
+Meslier,GKP,Leeds,4.5,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Cairns,GKP,Leeds,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Darlow,GKP,Leeds,4.0,3.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Bogle,DEF,Leeds,4.5,0.2,6.0,d,90,0,0,0,0,0,0,0.01,0.01,0.02,0.55,1,0,0,0,0,0,1,True,1.0,0.0,Everton,13.4,1.2,2.0,1.7,20,0,6,0,0,Arsenal (Home),1
+Struijk,DEF,Leeds,4.5,0.3,8.0,a,90,0,0,0,0,0,0,0.01,0.13,0.14,0.55,1,0,0,0,0,0,1,True,1.0,0.0,Everton,23.2,11.4,9.0,4.4,29,2,8,0,0,Arsenal (Home),1
+Bijol,DEF,Leeds,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Bornauw,DEF,Leeds,4.0,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Byram,DEF,Leeds,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Gudmundsson,DEF,Leeds,4.0,2.9,9.0,a,90,0,0,0,0,0,0,0.14,0.17,0.31,0.55,1,0,0,0,0,0,1,True,1.0,0.0,Everton,30.4,33.6,17.0,8.1,35,3,9,0,0,Arsenal (Home),1
+Rodon,DEF,Leeds,4.0,2.2,7.0,a,90,0,0,0,0,0,0,0.0,0.0,0.0,0.55,1,0,0,0,0,0,1,True,1.0,0.0,Everton,14.4,0.6,0.0,1.5,26,1,7,0,0,Arsenal (Home),1
+Schmidt,DEF,Leeds,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Aaronson,MID,Leeds,5.5,0.1,1.0,a,23,0,0,0,0,0,0,0.21,0.0,0.21,0.47,0,0,0,0,0,0,0,True,1.0,0.0,Everton,9.2,24.9,6.0,4.0,10,0,1,0,0,Arsenal (Home),1
+Gnonto,MID,Leeds,5.5,0.3,3.0,a,66,0,0,0,0,0,0,0.01,0.14,0.15,0.08,1,0,0,0,0,0,1,True,1.0,0.0,Everton,6.6,6.3,11.0,2.4,12,0,3,0,0,Arsenal (Home),1
+Harrison,MID,Leeds,5.5,0.1,1.0,a,12,0,0,0,0,0,0,0.0,0.0,0.0,0.28,0,0,0,0,0,0,0,True,1.0,0.0,Everton,2.2,1.3,2.0,0.6,3,0,1,0,0,Arsenal (Home),1
+James,MID,Leeds,5.5,0.5,3.0,a,77,0,0,0,0,0,0,0.05,0.14,0.19,0.28,1,0,0,0,0,0,1,True,1.0,0.0,Everton,6.2,15.7,11.0,3.3,6,0,3,0,0,Arsenal (Home),1
+Ampadu,MID,Leeds,5.0,0.1,3.0,a,77,0,0,0,0,0,0,0.02,0.0,0.02,0.28,1,0,0,0,0,0,1,True,1.0,0.0,Everton,10.8,4.9,2.0,1.8,12,0,3,0,0,Arsenal (Home),1
+Greenwood,MID,Leeds,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Gruev,MID,Leeds,5.0,0.0,1.0,a,12,0,0,0,0,0,0,0.0,0.0,0.0,0.28,0,0,0,0,0,0,0,True,1.0,0.0,Everton,1.6,0.3,0.0,0.2,3,0,1,0,0,Arsenal (Home),1
+Ramazani,MID,Leeds,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Tanaka,MID,Leeds,5.0,0.2,3.0,a,90,0,0,0,0,0,0,0.03,0.09,0.12,0.55,1,0,0,0,0,0,1,True,1.0,0.0,Everton,2.2,24.3,9.0,3.6,13,0,3,0,0,Arsenal (Home),1
+Crew,MID,Leeds,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Gelhardt,MID,Leeds,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Gyabi,MID,Leeds,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Piroe,FWD,Leeds,5.5,2.0,2.0,a,77,0,0,0,0,0,0,0.04,0.28,0.32,0.28,1,0,0,0,0,0,1,True,1.0,0.0,Everton,2.0,5.6,44.0,5.2,4,0,2,0,0,Arsenal (Home),1
+Bamford,FWD,Leeds,5.0,2.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Mateo Joseph,FWD,Leeds,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+Nmecha,FWD,Leeds,5.0,0.4,5.0,a,12,1,0,0,0,1,0,0.01,0.85,0.86,0.28,0,0,0,0,0,0,0,True,1.0,0.0,Everton,34.0,1.6,22.0,5.8,20,0,5,0,0,Arsenal (Home),1
+Longstaff,MID,Leeds,5.0,0.2,1.0,a,1,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,1.0,0.0,Everton,0.2,0.3,0.0,0.1,3,0,1,0,0,Arsenal (Home),1
+Stach,MID,Leeds,5.0,0.3,8.0,a,90,0,1,0,0,0,1,0.29,0.27,0.56,0.55,1,0,0,0,0,0,1,True,1.0,0.0,Everton,28.2,63.9,22.0,11.4,24,0,8,0,0,Arsenal (Home),1
+Perri,GKP,Leeds,4.5,0.4,6.0,a,90,0,0,1,0,0,0,0.0,0.0,0.0,0.55,1,0,0,0,0,0,1,True,1.0,0.0,Everton,11.2,0.0,0.0,1.1,24,0,6,0,0,Arsenal (Home),1
+Calvert-Lewin,FWD,Leeds,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,,0.0,0.0,0.0,0.0,0,0,0,0,0,Arsenal (Home),1
+A.Becker,GKP,Liverpool,5.5,11.2,1.0,a,90,0,0,1,2,0,0,0.01,0.0,0.01,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,13.6,0.0,0.0,1.4,8,0,1,0,0,Newcastle (Home),1
+Mamardashvili,GKP,Liverpool,4.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Pécsi,GKP,Liverpool,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Woodman,GKP,Liverpool,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Frimpong,DEF,Liverpool,6.0,29.7,1.0,a,59,0,0,0,0,0,0,0.01,0.01,0.02,0.81,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,5.4,1.3,2.0,0.9,8,0,1,0,0,Newcastle (Home),1
+Kerkez,DEF,Liverpool,6.0,6.3,0.0,a,59,0,0,0,0,0,0,0.01,0.0,0.01,0.81,0,0,0,0,1,0,1,True,4.0,2.0,Bournemouth,8.4,1.3,0.0,1.0,5,0,0,0,0,Newcastle (Home),1
+Robertson,DEF,Liverpool,6.0,1.3,0.0,a,30,0,0,0,2,0,0,0.04,0.0,0.04,0.89,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,5.4,4.1,2.0,1.2,-3,0,0,0,0,Newcastle (Home),1
+Virgil,DEF,Liverpool,6.0,23.9,3.0,a,90,0,0,0,2,0,0,0.01,0.18,0.19,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,49.4,0.9,25.0,7.5,11,0,3,0,0,Newcastle (Home),1
+Konaté,DEF,Liverpool,5.5,3.0,1.0,a,90,0,0,0,2,0,0,0.0,0.0,0.0,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,21.4,0.6,0.0,2.2,6,0,1,0,0,Newcastle (Home),1
+Bradley,DEF,Liverpool,5.0,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Gomez,DEF,Liverpool,5.0,0.1,1.0,a,18,0,0,0,1,0,0,0.0,0.0,0.0,0.21,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,2.4,0.4,0.0,0.3,-1,0,1,0,0,Newcastle (Home),1
+Tsimikas,DEF,Liverpool,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Nallo,DEF,Liverpool,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+R.Williams,DEF,Liverpool,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Ramsay,DEF,Liverpool,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+M.Salah,MID,Liverpool,14.5,54.2,8.0,a,90,1,0,0,2,1,0,0.11,0.26,0.37,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,49.0,33.8,51.0,13.4,36,1,8,0,0,Newcastle (Home),1
+Wirtz,MID,Liverpool,8.5,30.5,2.0,a,81,0,0,0,2,0,0,0.28,0.14,0.42,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,12.0,45.0,12.0,6.9,14,0,2,0,0,Newcastle (Home),1
+Luis Díaz,MID,Liverpool,8.0,0.1,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Gakpo,MID,Liverpool,7.5,8.1,7.0,a,90,1,0,0,2,1,0,0.44,0.2,0.64,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,48.2,39.6,46.0,13.4,34,0,7,0,0,Newcastle (Home),1
+Chiesa,MID,Liverpool,6.5,0.3,6.0,a,8,1,0,0,0,1,0,0.0,0.16,0.16,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,35.2,0.3,17.0,5.3,29,0,6,0,0,Newcastle (Home),1
+Mac Allister,MID,Liverpool,6.5,1.8,5.0,a,71,0,1,0,1,0,1,0.02,0.03,0.05,1.49,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,27.4,15.2,11.0,5.4,27,0,5,0,0,Newcastle (Home),1
+Szoboszlai,MID,Liverpool,6.5,2.0,2.0,a,90,0,0,0,2,0,0,0.09,0.1,0.19,1.7,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,14.0,29.8,24.0,6.8,17,0,2,0,0,Newcastle (Home),1
+C.Jones,MID,Liverpool,5.5,0.1,1.0,a,18,0,0,0,1,0,0,0.04,0.0,0.04,0.21,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,3.2,10.9,0.0,1.4,4,0,1,0,0,Newcastle (Home),1
+Elliott,MID,Liverpool,5.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Gravenberch,MID,Liverpool,5.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Doak,MID,Liverpool,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Endo,MID,Liverpool,5.0,0.1,4.0,a,30,0,1,0,2,0,1,0.0,0.0,0.0,0.89,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,24.6,10.7,0.0,3.5,15,0,4,0,0,Newcastle (Home),1
+Bajcetic,MID,Liverpool,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+McConnell,MID,Liverpool,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Morton,MID,Liverpool,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Nyoni,MID,Liverpool,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Darwin,FWD,Liverpool,6.5,0.1,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Danns,FWD,Liverpool,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Ekitiké,FWD,Liverpool,8.6,20.0,11.0,a,71,1,1,0,1,1,1,0.02,1.14,1.16,1.49,0,0,0,0,0,0,1,True,4.0,2.0,Bournemouth,52.8,24.4,37.0,11.4,37,2,11,0,0,Newcastle (Home),1
+Ngumoha,MID,Liverpool,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,4.0,2.0,Bournemouth,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Leoni,DEF,Liverpool,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,,0.0,0.0,0.0,0.0,0,0,0,0,0,Newcastle (Home),1
+Trafford,GKP,Man City,5.0,2.4,7.0,a,90,0,0,3,0,0,0,0.0,0.0,0.0,0.56,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,28.8,0.0,0.0,2.9,31,0,7,0,0,Spurs (Away),1
+Ederson M.,GKP,Man City,5.5,2.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Ortega Moreno,GKP,Man City,5.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Bettinelli,GKP,Man City,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Aït-Nouri,DEF,Man City,6.0,21.9,9.0,a,90,0,0,0,0,0,0,0.02,0.04,0.06,0.56,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,30.4,13.5,3.0,4.7,33,1,9,0,0,Spurs (Away),1
+Gvardiol,DEF,Man City,6.0,7.7,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Akanji,DEF,Man City,5.5,0.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Aké,DEF,Man City,5.5,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Khusanov,DEF,Man City,5.5,0.4,1.0,a,8,0,0,0,0,0,0,0.0,0.0,0.0,0.08,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,3.6,0.0,0.0,0.4,7,0,1,0,0,Spurs (Away),1
+Matheus N.,DEF,Man City,5.5,0.5,1.0,a,24,0,0,0,0,0,0,0.0,0.0,0.0,0.21,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,3.8,1.2,0.0,0.5,5,0,1,0,0,Spurs (Away),1
+Rúben,DEF,Man City,5.5,3.6,6.0,a,90,0,0,0,0,0,0,0.08,0.0,0.08,0.56,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,21.6,1.7,2.0,2.5,26,0,6,0,0,Spurs (Away),1
+Stones,DEF,Man City,5.5,0.8,6.0,a,81,0,0,0,0,0,0,0.01,0.0,0.01,0.47,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,14.4,2.2,0.0,1.7,28,0,6,0,0,Spurs (Away),1
+Lewis,DEF,Man City,5.0,2.2,11.0,a,65,0,1,0,0,0,1,0.59,0.0,0.59,0.35,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,29.2,13.1,8.0,5.0,41,2,11,0,0,Spurs (Away),1
+O’Reilly,DEF,Man City,5.0,0.2,0.0,a,24,0,0,0,0,0,0,0.01,0.0,0.01,0.21,0,0,0,0,1,0,0,False,0.0,4.0,Wolves,0.0,5.0,0.0,0.5,-2,0,0,0,0,Spurs (Away),1
+Vitor Reis,DEF,Man City,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Marmoush,MID,Man City,8.5,9.7,1.0,a,24,0,0,0,0,0,0,0.0,0.12,0.12,0.21,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.8,6.0,0.7,3,0,1,0,0,Spurs (Away),1
+Foden,MID,Man City,8.0,1.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Savinho,MID,Man City,7.0,0.8,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Bernardo,MID,Man City,6.5,0.8,3.0,a,65,0,0,0,0,0,0,0.44,0.0,0.44,0.35,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,22.0,62.0,4.0,8.8,25,0,3,0,0,Spurs (Away),1
+Cherki,MID,Man City,6.5,8.3,6.0,a,17,1,0,0,0,1,0,0.03,0.06,0.09,0.21,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,35.8,2.8,7.0,4.6,22,0,6,0,0,Spurs (Away),1
+Doku,MID,Man City,6.5,1.1,3.0,a,65,0,0,0,0,0,0,0.02,0.0,0.02,0.35,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,0.0,3.2,4.0,0.6,4,0,3,0,0,Spurs (Away),1
+Gündoğan,MID,Man City,6.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Rodrigo,MID,Man City,6.5,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Kovačić,MID,Man City,6.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+N.Gonzalez,MID,Man City,6.0,0.1,3.0,a,90,0,0,0,0,0,0,0.05,0.05,0.1,0.56,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,24.8,5.6,6.0,3.6,27,0,3,0,0,Spurs (Away),1
+Bobb,MID,Man City,5.5,0.3,6.0,a,90,0,1,0,0,0,1,0.07,0.0,0.07,0.56,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,24.6,25.4,8.0,5.8,25,0,6,0,0,Spurs (Away),1
+Echeverri,MID,Man City,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Reijnders,MID,Man City,5.6,26.5,10.0,a,90,1,1,0,0,1,1,0.14,0.2,0.34,0.56,1,0,0,0,1,0,1,False,0.0,4.0,Wolves,49.8,23.7,28.0,10.2,31,0,10,0,0,Spurs (Away),1
+Nypan,MID,Man City,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Phillips,MID,Man City,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Spurs (Away),1
+Haaland,FWD,Man City,14.0,27.6,13.0,a,72,2,0,0,0,2,0,0.0,1.99,1.99,0.35,1,0,0,0,0,0,1,False,0.0,4.0,Wolves,58.0,0.3,71.0,12.9,49,3,13,0,0,Spurs (Away),1
+Mbeumo,MID,Man Utd,8.0,14.0,2.0,a,90,0,0,0,1,0,0,0.05,0.42,0.47,1.31,0,0,0,0,0,0,1,True,0.0,1.0,Arsenal,10.6,21.4,49.0,8.1,17,0,2,0,0,Fulham (Home),1
+Bayindir,GKP,Man Utd,5.0,0.4,2.0,a,90,0,0,2,1,0,0,0.0,0.0,0.0,1.31,0,0,0,0,0,0,1,True,0.0,1.0,Arsenal,13.4,0.0,0.0,1.3,11,0,2,0,0,Fulham (Home),1
+Onana,GKP,Man Utd,5.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Harrison,GKP,Man Utd,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Heaton,GKP,Man Utd,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Mee,GKP,Man Utd,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+De Ligt,DEF,Man Utd,5.0,2.0,4.0,a,90,0,0,0,1,0,0,0.06,0.21,0.27,1.31,0,0,0,0,0,0,1,True,0.0,1.0,Arsenal,33.4,16.0,26.0,7.5,16,0,4,0,0,Fulham (Home),1
+Martinez,DEF,Man Utd,5.0,0.2,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Mazraoui,DEF,Man Utd,5.0,0.2,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+D.Leon,DEF,Man Utd,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Dalot,DEF,Man Utd,4.5,2.2,1.0,a,54,0,0,0,1,0,0,0.15,0.0,0.15,1.03,0,0,0,0,0,0,1,True,0.0,1.0,Arsenal,6.8,14.1,2.0,2.3,2,0,1,0,0,Fulham (Home),1
+Dorgu,DEF,Man Utd,4.5,7.0,1.0,a,90,0,0,0,1,0,0,0.02,0.04,0.06,1.31,0,0,0,0,1,0,1,True,0.0,1.0,Arsenal,9.0,2.8,8.0,2.0,4,0,1,0,0,Fulham (Home),1
+Maguire,DEF,Man Utd,4.5,0.7,1.0,a,10,0,0,0,0,0,0,0.0,0.0,0.0,0.21,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,5.2,0.5,0.0,0.6,2,0,1,0,0,Fulham (Home),1
+Shaw,DEF,Man Utd,4.5,0.3,2.0,a,79,0,0,0,1,0,0,0.02,0.0,0.02,1.1,0,0,0,0,0,0,1,True,0.0,1.0,Arsenal,11.2,12.5,0.0,2.4,7,0,2,0,0,Fulham (Home),1
+Yoro,DEF,Man Utd,4.5,1.7,4.0,a,90,0,0,0,1,0,0,0.01,0.0,0.01,1.31,0,0,0,0,0,0,1,True,0.0,1.0,Arsenal,18.2,2.6,0.0,2.1,11,0,4,0,0,Fulham (Home),1
+Amass,DEF,Man Utd,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Fredricson,DEF,Man Utd,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Heaven,DEF,Man Utd,4.0,1.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Malacia,DEF,Man Utd,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+B.Fernandes,MID,Man Utd,9.0,21.7,2.0,a,90,0,0,0,1,0,0,0.3,0.15,0.45,1.31,0,0,0,0,0,0,1,True,0.0,1.0,Arsenal,25.2,65.3,9.0,10.0,19,0,2,0,0,Fulham (Home),1
+Cunha,MID,Man Utd,8.0,8.4,2.0,a,90,0,0,0,1,0,0,0.05,0.4,0.45,1.31,0,0,0,0,0,0,1,True,0.0,1.0,Arsenal,17.8,13.3,50.0,8.1,16,0,2,0,0,Fulham (Home),1
+Rashford,MID,Man Utd,7.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Amad,MID,Man Utd,6.5,2.8,1.0,a,35,0,0,0,0,0,0,0.04,0.03,0.07,0.27,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,13.4,12.3,19.0,4.5,12,0,1,0,0,Fulham (Home),1
+Garnacho,MID,Man Utd,6.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Antony,MID,Man Utd,6.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Mount,MID,Man Utd,6.0,0.3,2.0,a,64,0,0,0,1,0,0,0.15,0.12,0.27,1.1,0,0,0,0,0,0,1,True,0.0,1.0,Arsenal,7.0,25.1,18.0,5.0,9,0,2,0,0,Fulham (Home),1
+Sancho,MID,Man Utd,6.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Casemiro,MID,Man Utd,5.5,0.2,2.0,a,64,0,0,0,1,0,0,0.02,0.0,0.02,1.1,0,0,0,0,0,0,1,True,0.0,1.0,Arsenal,9.2,11.6,0.0,2.1,15,0,2,0,0,Fulham (Home),1
+Mainoo,MID,Man Utd,5.0,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Ugarte,MID,Man Utd,5.0,0.2,1.0,a,25,0,0,0,0,0,0,0.01,0.03,0.04,0.21,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,11.4,1.0,1.2,0,0,1,0,0,Fulham (Home),1
+Collyer,MID,Man Utd,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Fitzgerald,MID,Man Utd,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+J.Fletcher,MID,Man Utd,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Kone,MID,Man Utd,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Moorhouse,MID,Man Utd,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Højlund,FWD,Man Utd,6.5,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Zirkzee,FWD,Man Utd,6.0,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Obi,FWD,Man Utd,4.5,2.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Wheatley,FWD,Man Utd,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,0.0,0.0,0.0,0,0,0,0,0,Fulham (Home),1
+Šeško,FWD,Man Utd,7.5,8.9,1.0,a,25,0,0,0,0,0,0,0.06,0.11,0.17,0.21,0,0,0,0,0,0,0,True,0.0,1.0,Arsenal,0.0,20.5,12.0,3.2,2,0,1,0,0,Fulham (Home),1
+Pope,GKP,Newcastle,5.0,3.9,9.0,a,90,0,0,3,0,0,0,0.0,0.0,0.0,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,27.0,0.0,0.0,2.7,32,2,9,0,0,Liverpool (Away),1
+Gillespie,GKP,Newcastle,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Odysseas,GKP,Newcastle,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Hall,DEF,Newcastle,5.5,1.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Schär,DEF,Newcastle,5.5,2.8,8.0,a,90,0,0,0,0,0,0,0.03,0.04,0.07,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,13.8,1.9,4.0,2.0,26,0,8,0,0,Liverpool (Away),1
+Botman,DEF,Newcastle,5.0,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Burn,DEF,Newcastle,5.0,3.9,9.0,a,90,0,0,0,0,0,0,0.01,0.0,0.01,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,18.6,1.2,2.0,2.2,30,1,9,0,0,Liverpool (Away),1
+Livramento,DEF,Newcastle,5.0,4.0,9.0,a,90,0,0,0,0,0,0,0.03,0.0,0.03,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,18.0,25.4,4.0,4.7,33,3,9,0,0,Liverpool (Away),1
+Trippier,DEF,Newcastle,5.0,2.2,6.0,a,90,0,0,0,0,0,0,0.06,0.0,0.06,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,9.8,22.5,0.0,3.2,26,0,6,0,0,Liverpool (Away),1
+Krafth,DEF,Newcastle,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Lascelles,DEF,Newcastle,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+A.Murphy,DEF,Newcastle,4.0,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Ashby,DEF,Newcastle,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Pivas,DEF,Newcastle,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Targett,DEF,Newcastle,4.0,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Gordon,MID,Newcastle,7.5,1.9,3.0,a,90,0,0,0,0,0,0,0.03,0.55,0.58,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,5.4,13.0,41.0,5.9,4,0,3,0,0,Liverpool (Away),1
+Elanga,MID,Newcastle,7.0,7.8,3.0,a,77,0,0,0,0,0,0,0.06,0.57,0.63,0.17,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,8.6,29.8,27.0,6.5,10,0,3,0,0,Liverpool (Away),1
+Barnes,MID,Newcastle,6.5,0.6,3.0,a,89,0,0,0,0,0,0,0.33,0.23,0.56,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,12.8,56.8,25.0,9.5,15,0,3,0,0,Liverpool (Away),1
+Bruno G.,MID,Newcastle,6.5,1.6,3.0,a,90,0,0,0,0,0,0,0.1,0.0,0.1,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,7.6,22.6,2.0,3.2,11,0,3,0,0,Liverpool (Away),1
+J.Murphy,MID,Newcastle,6.5,2.1,1.0,a,12,0,0,0,0,0,0,0.01,0.0,0.01,0.03,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.6,1.3,4.0,0.6,3,0,1,0,0,Liverpool (Away),1
+Joelinton,MID,Newcastle,6.0,0.5,2.0,a,82,0,0,0,0,0,0,0.02,0.0,0.02,0.17,1,0,0,0,1,0,1,False,0.0,0.0,Aston Villa,4.4,4.2,6.0,1.5,7,0,2,0,0,Liverpool (Away),1
+Tonali,MID,Newcastle,5.5,1.8,3.0,a,90,0,0,0,0,0,0,0.18,0.0,0.18,0.2,1,0,0,0,0,0,1,False,0.0,0.0,Aston Villa,13.8,29.2,0.0,4.3,20,0,3,0,0,Liverpool (Away),1
+Antoñito C.,MID,Newcastle,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Willock,MID,Newcastle,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Hayden,MID,Newcastle,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Kuol,MID,Newcastle,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+L.Miley,MID,Newcastle,4.5,2.6,1.0,a,7,0,0,0,0,0,0,0.01,0.0,0.01,0.03,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,2.6,11.0,2.0,1.6,4,0,1,0,0,Liverpool (Away),1
+White,MID,Newcastle,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Isak,FWD,Newcastle,10.5,5.8,0.0,n,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Osula,FWD,Newcastle,5.5,0.2,1.0,a,1,0,0,0,0,0,0,0.02,0.03,0.05,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.3,7.0,0.7,3,0,1,0,0,Liverpool (Away),1
+Neave,FWD,Newcastle,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Ramsdale,GKP,Newcastle,5.0,0.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Thiaw,DEF,Newcastle,5.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+Seung soo,MID,Newcastle,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,0.0,Aston Villa,0.0,0.0,0.0,0.0,0,0,0,0,0,Liverpool (Away),1
+McAtee,MID,Nott'm Forest,5.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,0.0,4.0,Wolves,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Sels,GKP,Nott'm Forest,5.0,19.9,2.0,a,90,0,0,2,1,0,0,0.0,0.0,0.0,1.5,0,0,0,0,0,0,1,True,3.0,1.0,Brentford,14.6,0.0,0.0,1.5,9,0,2,0,0,Crystal Palace (Home),1
+C.Miguel,GKP,Nott'm Forest,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Turner,GKP,Nott'm Forest,4.0,0.2,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Milenković,DEF,Nott'm Forest,5.5,9.9,2.0,a,90,0,0,0,1,0,0,0.0,0.0,0.0,1.5,0,0,0,0,0,0,1,True,3.0,1.0,Brentford,17.2,0.5,0.0,1.8,5,0,2,0,0,Crystal Palace (Home),1
+Murillo,DEF,Nott'm Forest,5.5,6.9,2.0,a,90,0,0,0,1,0,0,0.02,0.0,0.02,1.5,0,0,0,0,0,0,1,True,3.0,1.0,Brentford,11.8,1.6,0.0,1.3,12,0,2,0,0,Crystal Palace (Home),1
+Aina,DEF,Nott'm Forest,5.0,14.7,4.0,a,90,0,0,0,1,0,0,0.04,0.0,0.04,1.5,0,0,0,0,0,0,1,True,3.0,1.0,Brentford,27.2,16.1,2.0,4.5,15,0,4,0,0,Crystal Palace (Home),1
+N.Williams,DEF,Nott'm Forest,5.0,10.2,1.0,a,90,0,0,0,1,0,0,0.09,0.0,0.09,1.5,0,0,0,0,1,0,1,True,3.0,1.0,Brentford,19.0,28.8,2.0,5.0,10,0,1,0,0,Crystal Palace (Home),1
+David Carmo,DEF,Nott'm Forest,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Jair Cunha,DEF,Nott'm Forest,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Morato,DEF,Nott'm Forest,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+O.Richards,DEF,Nott'm Forest,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Abbott,DEF,Nott'm Forest,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Boly,DEF,Nott'm Forest,4.0,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Gibbs-White,MID,Nott'm Forest,7.5,5.2,5.0,a,83,0,1,0,1,0,1,0.28,0.38,0.66,1.5,0,0,0,0,0,0,1,True,3.0,1.0,Brentford,28.8,51.8,15.0,9.6,23,0,5,0,0,Crystal Palace (Home),1
+Hudson-Odoi,MID,Nott'm Forest,6.0,1.2,2.0,a,90,0,0,0,1,0,0,0.24,0.02,0.26,1.5,0,0,0,0,0,0,1,True,3.0,1.0,Brentford,11.8,32.3,9.0,5.3,20,0,2,0,0,Crystal Palace (Home),1
+Anderson,MID,Nott'm Forest,5.5,6.5,6.0,a,90,0,1,0,1,0,1,0.28,0.39,0.67,1.5,0,0,0,0,0,0,1,True,3.0,1.0,Brentford,28.6,21.3,20.0,7.0,24,1,6,0,0,Crystal Palace (Home),1
+Jota,MID,Nott'm Forest,5.5,0.1,1.0,a,11,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,5.0,0.5,4.0,1.0,6,0,1,0,0,Crystal Palace (Home),1
+Dominguez,MID,Nott'm Forest,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+O'Brien,MID,Nott'm Forest,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Sangaré,MID,Nott'm Forest,5.0,0.1,2.0,a,90,0,0,0,1,0,0,0.01,0.02,0.03,1.5,0,0,0,0,0,0,1,True,3.0,1.0,Brentford,1.4,4.2,1.0,0.7,11,0,2,0,0,Crystal Palace (Home),1
+Yates,MID,Nott'm Forest,5.0,0.1,1.0,a,6,0,0,0,0,0,0,0.01,0.0,0.01,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,4.6,1.6,2.0,0.8,7,0,1,0,0,Crystal Palace (Home),1
+Da Silva Moreira,MID,Nott'm Forest,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Stamenic,MID,Nott'm Forest,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Wood,FWD,Nott'm Forest,7.6,16.8,13.0,a,78,2,0,0,1,2,0,0.01,0.95,0.96,1.5,0,0,0,0,0,0,1,True,3.0,1.0,Brentford,66.2,4.3,54.0,12.5,58,3,13,0,0,Crystal Palace (Home),1
+Igor Jesus,FWD,Nott'm Forest,6.0,0.8,1.0,a,11,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,1.0,1.5,2.0,0.5,2,0,1,0,0,Crystal Palace (Home),1
+Awoniyi,FWD,Nott'm Forest,5.5,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Ndoye,MID,Nott'm Forest,6.0,0.5,9.0,a,78,1,0,0,1,1,0,0.01,0.1,0.11,1.5,0,0,0,0,0,0,1,True,3.0,1.0,Brentford,32.2,0.8,27.0,6.0,29,2,9,0,0,Crystal Palace (Home),1
+Gunn,GKP,Nott'm Forest,4.0,1.9,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,1.0,Brentford,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Hutchinson,MID,Nott'm Forest,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,,0.0,0.0,0.0,0.0,0,0,0,0,0,Crystal Palace (Home),1
+Marc Guiu,FWD,Sunderland,4.5,20.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Patterson,GKP,Sunderland,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Moore,GKP,Sunderland,4.0,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Nna Noukeu,GKP,Sunderland,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Ballard,DEF,Sunderland,4.5,3.4,17.0,a,90,1,0,0,0,1,0,0.01,0.18,0.19,0.56,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,69.6,0.5,64.0,13.4,53,3,17,0,0,Burnley (Home),1
+Hume,DEF,Sunderland,4.5,0.2,6.0,a,90,0,0,0,0,0,0,0.09,0.0,0.09,0.56,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,15.2,15.8,2.0,3.3,27,0,6,0,0,Burnley (Home),1
+Alese,DEF,Sunderland,4.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Anderson,DEF,Sunderland,4.0,0.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Cirkin,DEF,Sunderland,4.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Hjelde,DEF,Sunderland,4.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Huggins,DEF,Sunderland,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Johnson,DEF,Sunderland,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+O'Nien,DEF,Sunderland,4.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Pembele,DEF,Sunderland,4.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Reinildo,DEF,Sunderland,4.0,7.8,6.0,a,90,0,0,0,0,0,0,0.0,0.0,0.0,0.56,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,13.6,2.5,0.0,1.6,27,0,6,0,0,Burnley (Home),1
+Seelt,DEF,Sunderland,4.0,0.3,1.0,d,52,0,0,0,0,0,0,0.0,0.0,0.0,0.33,0,0,0,0,0,0,1,True,3.0,0.0,West Ham,15.2,0.6,0.0,1.6,6,0,1,0,0,Burnley (Home),1
+Adingra,MID,Sunderland,5.5,1.7,6.0,a,75,0,1,0,0,0,1,0.02,0.14,0.16,0.33,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,0.0,14.5,6.0,2.0,8,0,6,0,0,Burnley (Home),1
+Diarra,MID,Sunderland,5.5,0.1,3.0,a,90,0,0,0,0,0,0,0.01,0.23,0.24,0.56,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,7.0,2.8,20.0,3.0,4,0,3,0,0,Burnley (Home),1
+Roberts,MID,Sunderland,5.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Aleksić,MID,Sunderland,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+E.Le Fée,MID,Sunderland,5.0,0.3,1.0,a,14,0,0,0,0,0,0,0.0,0.0,0.0,0.23,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,3.2,0.3,0.0,0.4,4,0,1,0,0,Burnley (Home),1
+Mundle,MID,Sunderland,5.0,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Neil,MID,Sunderland,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Poveda,MID,Sunderland,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Rigg,MID,Sunderland,5.0,0.1,1.0,a,1,0,0,0,0,0,0,0.0,0.0,0.0,0.03,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,3,0,1,0,0,Burnley (Home),1
+Sadiki,MID,Sunderland,5.0,0.0,3.0,a,90,0,0,0,0,0,0,0.01,0.0,0.01,0.56,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,11.0,3.8,0.0,1.5,6,0,3,0,0,Burnley (Home),1
+Talbi,MID,Sunderland,5.0,0.3,6.0,a,90,0,1,0,0,0,1,0.01,0.0,0.01,0.53,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,20.8,18.4,2.0,4.1,17,0,6,0,0,Burnley (Home),1
+Ba,MID,Sunderland,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Browne,MID,Sunderland,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Ekwah,MID,Sunderland,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+H.Jones,MID,Sunderland,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Matete,MID,Sunderland,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Triantis,MID,Sunderland,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Isidor,FWD,Sunderland,5.5,0.3,5.0,a,14,1,0,0,0,1,0,0.0,0.04,0.04,0.23,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,34.2,0.1,17.0,5.1,29,0,5,0,0,Burnley (Home),1
+Mayenda,FWD,Sunderland,5.5,1.2,8.0,a,75,1,0,0,0,1,0,0.0,0.09,0.09,0.33,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,34.0,11.3,26.0,7.1,37,2,8,0,0,Burnley (Home),1
+Abdullahi,FWD,Sunderland,4.5,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Luís Hemir,FWD,Sunderland,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Rusyn,FWD,Sunderland,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Xhaka,MID,Sunderland,5.0,2.9,3.0,a,90,0,0,0,0,0,0,0.04,0.0,0.04,0.56,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,15.4,31.8,0.0,4.7,10,0,3,0,0,Burnley (Home),1
+Roefs,GKP,Sunderland,4.5,0.7,8.0,a,90,0,0,4,0,0,0,0.0,0.0,0.0,0.56,1,0,0,0,0,0,1,True,3.0,0.0,West Ham,30.0,0.0,0.0,3.0,31,1,8,0,0,Burnley (Home),1
+Masuaku,DEF,Sunderland,4.0,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Alderete,DEF,Sunderland,4.0,1.2,4.0,a,37,0,1,0,0,0,1,0.12,0.0,0.12,0.23,0,0,0,0,0,0,0,True,3.0,0.0,West Ham,30.0,14.4,0.0,4.4,16,0,4,0,0,Burnley (Home),1
+Mukiele,DEF,Sunderland,4.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,,,,0.0,0.0,0.0,0.0,0,0,0,0,0,Burnley (Home),1
+Vicario,GKP,Spurs,5.0,4.4,9.0,a,90,0,0,4,0,0,0,0.0,0.0,0.0,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,30.0,0.0,0.0,3.0,36,2,9,0,0,Man City (Home),1
+Austin,GKP,Spurs,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Kinsky,GKP,Spurs,4.0,2.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Pedro Porro,DEF,Spurs,5.5,22.4,6.0,a,90,0,0,0,0,0,0,0.26,0.02,0.28,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,21.2,42.8,1.0,6.5,26,0,6,0,0,Man City (Home),1
+Romero,DEF,Spurs,5.0,3.7,6.0,a,90,0,0,0,0,0,0,0.02,0.0,0.02,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,18.0,1.4,6.0,2.5,22,0,6,0,0,Man City (Home),1
+Danso,DEF,Spurs,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Davies,DEF,Spurs,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Dragusin,DEF,Spurs,4.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Spence,DEF,Spurs,4.5,1.3,6.0,a,90,0,0,0,0,0,0,0.07,0.18,0.25,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,10.0,5.8,22.0,3.8,26,0,6,0,0,Man City (Home),1
+Udogie,DEF,Spurs,4.5,0.7,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Van de Ven,DEF,Spurs,4.5,27.6,6.0,a,90,0,0,0,0,0,0,0.01,0.59,0.6,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,11.6,1.0,14.0,2.7,27,0,6,0,0,Man City (Home),1
+Phillips,DEF,Spurs,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Takai,DEF,Spurs,4.0,0.1,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Vuskovic,DEF,Spurs,4.0,1.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Son,MID,Spurs,8.5,0.3,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Johnson,MID,Spurs,7.0,3.1,8.0,a,79,1,0,0,0,1,0,0.06,0.5,0.56,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,40.4,27.1,20.0,8.8,30,0,8,0,0,Man City (Home),1
+Maddison,MID,Spurs,7.0,0.3,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Kudus,MID,Spurs,6.5,26.9,10.0,a,84,0,2,0,0,0,2,0.58,0.06,0.64,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,45.4,74.0,11.0,13.0,35,1,10,0,0,Man City (Home),1
+Kulusevski,MID,Spurs,6.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Tel,MID,Spurs,6.5,0.1,1.0,a,5,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.1,0.0,0.0,1,0,1,0,0,Man City (Home),1
+Bentancur,MID,Spurs,5.5,0.2,1.0,a,19,0,0,0,0,0,0,0.0,0.0,0.0,0.04,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,4.8,0.8,0.0,0.6,5,0,1,0,0,Man City (Home),1
+Bergvall,MID,Spurs,5.5,0.2,3.0,a,79,0,0,0,0,0,0,0.01,0.12,0.13,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,10.4,3.3,33.0,4.7,13,0,3,0,0,Man City (Home),1
+Bissouma,MID,Spurs,5.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Odobert,MID,Spurs,5.5,0.0,1.0,a,10,0,0,0,0,0,0,0.01,0.0,0.01,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,2.2,10.5,0.0,1.3,4,0,1,0,0,Man City (Home),1
+Solomon,MID,Spurs,5.5,0.0,0.0,d,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Bryan,MID,Spurs,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Gray,MID,Spurs,5.0,0.2,3.0,a,70,0,0,0,0,0,0,0.05,0.0,0.05,0.89,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,3.6,3.0,2.0,0.9,13,0,3,0,0,Man City (Home),1
+Moore,MID,Spurs,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+P.M.Sarr,MID,Spurs,5.0,2.8,6.0,a,90,0,1,0,0,0,1,0.22,0.0,0.22,0.94,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,33.2,18.7,2.0,5.4,29,0,6,0,0,Man City (Home),1
+Min-hyeok,MID,Spurs,4.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Olusesi,MID,Spurs,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Solanke,FWD,Spurs,7.5,4.1,1.0,a,19,0,0,0,0,0,0,0.0,0.08,0.08,0.04,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,2.0,0.3,6.0,0.8,5,0,1,0,0,Man City (Home),1
+Richarlison,FWD,Spurs,6.5,4.8,13.0,a,71,2,0,0,0,2,0,0.01,0.78,0.79,0.89,1,0,0,0,0,0,1,True,3.0,0.0,Burnley,73.6,0.5,80.0,15.4,61,3,13,0,0,Man City (Home),1
+Lankshear,FWD,Spurs,4.5,0.1,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+Scarlett,FWD,Spurs,4.5,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.0,0.0,0.0,0.0,0,0,0,0,0,Man City (Home),1
+J.Palhinha,MID,Spurs,5.5,0.4,1.0,a,10,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,3.0,0.0,Burnley,0.2,0.6,0.0,0.1,2,0,1,0,0,Man City (Home),1
+Areola,GKP,West Ham,4.5,4.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+Foderingham,GKP,West Ham,4.0,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+Hegyi,GKP,West Ham,4.0,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+Diouf,DEF,West Ham,4.5,7.2,1.0,a,90,0,0,0,3,0,0,0.07,0.16,0.23,0.68,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,10.8,30.7,10.0,5.2,4,0,1,0,0,Chelsea (Away),1
+Emerson,DEF,West Ham,4.5,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+Kilman,DEF,West Ham,4.5,0.3,0.0,a,90,0,0,0,3,0,0,0.03,0.0,0.03,0.68,0,0,0,0,1,0,1,False,3.0,0.0,Sunderland,27.2,16.2,0.0,4.3,4,0,0,0,0,Chelsea (Away),1
+Mavropanos,DEF,West Ham,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+N.Aguerd,DEF,West Ham,4.5,0.1,1.0,a,90,0,0,0,3,0,0,0.02,0.0,0.02,0.68,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,14.6,3.0,0.0,1.8,1,0,1,0,0,Chelsea (Away),1
+Scarles,DEF,West Ham,4.5,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+Todibo,DEF,West Ham,4.5,0.1,1.0,a,81,0,0,0,2,0,0,0.01,0.0,0.01,0.64,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,19.8,3.1,0.0,2.3,9,0,1,0,0,Chelsea (Away),1
+Wan-Bissaka,DEF,West Ham,4.5,23.4,1.0,a,90,0,0,0,3,0,0,0.07,0.0,0.07,0.68,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,17.8,24.7,8.0,5.1,9,0,1,0,0,Chelsea (Away),1
+Casey,DEF,West Ham,4.0,0.2,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+L.Paquetá,MID,West Ham,6.0,1.0,2.0,a,90,0,0,0,3,0,0,0.08,0.0,0.08,0.68,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,5.8,14.2,4.0,2.4,11,0,2,0,0,Chelsea (Away),1
+Souček,MID,West Ham,6.0,0.8,1.0,a,19,0,0,0,2,0,0,0.0,0.07,0.07,0.08,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,4.2,1.3,19.0,2.5,4,0,1,0,0,Chelsea (Away),1
+Ward-Prowse,MID,West Ham,6.0,0.4,2.0,a,70,0,0,0,1,0,0,0.02,0.0,0.02,0.6,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,5.8,15.2,2.0,2.3,13,0,2,0,0,Chelsea (Away),1
+Summerville,MID,West Ham,5.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+Álvarez,MID,West Ham,5.0,0.2,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+Cornet,MID,West Ham,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+G.Rodriguez,MID,West Ham,5.0,0.1,2.0,a,70,0,0,0,1,0,0,0.03,0.03,0.06,0.6,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,2.2,2.3,2.0,0.7,11,0,2,0,0,Chelsea (Away),1
+L.Guilherme,MID,West Ham,5.0,0.0,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+Earthy,MID,West Ham,4.5,0.1,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+Irving,MID,West Ham,4.5,0.3,1.0,a,8,0,0,0,1,0,0,0.06,0.0,0.06,0.04,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,4.4,14.8,0.0,1.9,6,0,1,0,0,Chelsea (Away),1
+Orford,MID,West Ham,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+Potts,MID,West Ham,4.5,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+Bowen,FWD,West Ham,8.0,14.9,2.0,a,90,0,0,0,3,0,0,0.05,0.15,0.2,0.68,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,10.6,4.3,34.0,4.9,13,0,2,0,0,Chelsea (Away),1
+Füllkrug,FWD,West Ham,6.0,3.4,2.0,a,90,0,0,0,3,0,0,0.08,0.14,0.22,0.68,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,0.8,14.5,34.0,4.9,-1,0,2,0,0,Chelsea (Away),1
+Marshall,FWD,West Ham,4.5,0.7,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+Walker-Peters,DEF,West Ham,4.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,0.0,0.0,0,0,0,0,0,Chelsea (Away),1
+Wilson,FWD,West Ham,6.0,0.5,1.0,a,19,0,0,0,2,0,0,0.0,0.02,0.02,0.08,0,0,0,0,0,0,0,False,3.0,0.0,Sunderland,0.0,0.0,8.0,0.5,2,0,1,0,0,Chelsea (Away),1
+Hermansen,GKP,West Ham,4.5,0.3,1.0,a,90,0,0,2,3,0,0,0.01,0.0,0.01,0.68,0,0,0,0,0,0,1,False,3.0,0.0,Sunderland,21.0,0.0,0.0,2.1,3,0,1,0,0,Chelsea (Away),1
+Johnstone,GKP,Wolves,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+José Sá,GKP,Wolves,4.5,2.0,0.0,a,90,0,0,0,4,0,0,0.0,0.0,0.0,2.47,0,0,0,0,0,0,1,True,0.0,4.0,Man City,3.6,0.0,0.0,0.4,-8,0,0,0,0,Bournemouth (Home),1
+Bentley,GKP,Wolves,4.0,0.8,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Agbadou,DEF,Wolves,4.5,0.4,0.0,a,90,0,0,0,4,0,0,0.01,0.02,0.03,2.47,0,0,0,0,0,0,1,True,0.0,4.0,Man City,11.8,0.3,1.0,1.3,-7,0,0,0,0,Bournemouth (Home),1
+Doherty,DEF,Wolves,4.5,0.2,-1.0,a,90,0,0,0,4,0,0,0.01,0.0,0.01,2.47,0,0,0,0,1,0,1,True,0.0,4.0,Man City,9.8,5.9,0.0,1.6,-1,0,-1,0,0,Bournemouth (Home),1
+H.Bueno,DEF,Wolves,4.5,0.1,1.0,a,18,0,0,0,1,0,0,0.01,0.0,0.01,0.24,0,0,0,0,0,0,0,True,0.0,4.0,Man City,4.4,11.1,6.0,2.2,0,0,1,0,0,Bournemouth (Home),1
+Mosquera,DEF,Wolves,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+R.Gomes,DEF,Wolves,4.5,0.1,1.0,a,17,0,0,0,1,0,0,0.0,0.0,0.0,0.24,0,0,0,0,0,0,0,True,0.0,4.0,Man City,2.2,1.0,4.0,0.7,-1,0,1,0,0,Bournemouth (Home),1
+S.Bueno,DEF,Wolves,4.5,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Toti,DEF,Wolves,4.5,0.2,0.0,a,90,0,0,0,4,0,0,0.0,0.0,0.0,2.47,0,0,0,0,0,0,1,True,0.0,4.0,Man City,14.6,10.8,0.0,2.5,0,0,0,0,0,Bournemouth (Home),1
+Hoever,DEF,Wolves,4.0,2.4,1.0,a,72,0,0,0,3,0,0,0.14,0.0,0.14,2.22,0,0,0,0,0,0,1,True,0.0,4.0,Man City,17.6,19.8,0.0,3.7,0,0,1,0,0,Bournemouth (Home),1
+Meupiyou,DEF,Wolves,4.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Pedro Lima,DEF,Wolves,4.0,1.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Pond,DEF,Wolves,4.0,1.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Hee Chan,MID,Wolves,6.0,0.2,1.0,a,8,0,0,0,0,0,0,0.02,0.0,0.02,0.19,0,0,0,0,0,0,0,True,0.0,4.0,Man City,3.0,10.3,0.0,1.3,3,0,1,0,0,Bournemouth (Home),1
+André,MID,Wolves,5.5,0.1,4.0,a,71,0,0,0,3,0,0,0.01,0.0,0.01,2.22,0,0,0,0,0,0,1,True,0.0,4.0,Man City,15.6,1.7,0.0,1.7,16,0,4,0,0,Bournemouth (Home),1
+Bellegarde,MID,Wolves,5.5,0.1,2.0,a,72,0,0,0,3,0,0,0.03,0.02,0.05,2.22,0,0,0,0,0,0,1,True,0.0,4.0,Man City,4.6,17.7,5.0,2.7,5,0,2,0,0,Bournemouth (Home),1
+Fer López,MID,Wolves,5.5,0.0,1.0,a,18,0,0,0,1,0,0,0.02,0.08,0.1,0.24,0,0,0,0,0,0,0,True,0.0,4.0,Man City,3.4,0.6,19.0,2.3,5,0,1,0,0,Bournemouth (Home),1
+Gomes,MID,Wolves,5.5,0.1,2.0,a,90,0,0,0,4,0,0,0.04,0.0,0.04,2.47,0,0,0,0,0,0,1,True,0.0,4.0,Man City,19.4,14.8,4.0,3.8,20,0,2,0,0,Bournemouth (Home),1
+Guedes,MID,Wolves,5.5,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Munetsi,MID,Wolves,5.5,0.1,2.0,a,90,0,0,0,4,0,0,0.02,0.05,0.07,2.47,0,0,0,0,0,0,1,True,0.0,4.0,Man City,8.4,6.5,7.0,2.2,10,0,2,0,0,Bournemouth (Home),1
+B.Traore,MID,Wolves,5.0,0.0,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Chirewa,MID,Wolves,4.5,0.3,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Edozie,MID,Wolves,4.5,0.4,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Gonzalez,MID,Wolves,4.5,1.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Hodge,MID,Wolves,4.5,0.1,0.0,u,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Strand Larsen,FWD,Wolves,6.5,4.7,2.0,a,81,0,0,0,4,0,0,0.01,0.38,0.39,2.28,0,0,0,0,0,0,1,True,0.0,4.0,Man City,11.0,2.3,45.0,5.8,8,0,2,0,0,Bournemouth (Home),1
+Fábio Silva,FWD,Wolves,5.0,0.6,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Kalajdžić,FWD,Wolves,5.0,0.1,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Chiwome,FWD,Wolves,4.5,0.0,0.0,i,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+Fraser,FWD,Wolves,4.5,2.5,0.0,a,0,0,0,0,0,0,0,0.0,0.0,0.0,0.0,0,0,0,0,0,0,0,True,0.0,4.0,Man City,0.0,0.0,0.0,0.0,0,0,0,0,0,Bournemouth (Home),1
+J.Arias,MID,Wolves,5.5,0.6,1.0,a,17,0,0,0,1,0,0,0.02,0.0,0.02,0.24,0,0,0,0,0,0,0,True,0.0,4.0,Man City,2.2,12.0,2.0,1.6,2,0,1,0,0,Bournemouth (Home),1
+Møller Wolfe,DEF,Wolves,4.5,0.1,1.0,a,71,0,0,0,3,0,0,0.0,0.0,0.0,2.22,0,0,0,0,0,0,1,True,0.0,4.0,Man City,7.2,0.8,2.0,1.0,-4,0,1,0,0,Bournemouth (Home),1

--- a/merge_gws.py
+++ b/merge_gws.py
@@ -20,15 +20,25 @@ def find_gw_files(root_dir):
 def merge_gw_files(gw_files):
     all_dfs = []
     for file in gw_files:
-        df = pd.read_csv(file)
-        gw_number = re.search(r'GW_(\d+)', file).group(1)
-        df['GW'] = gw_number
-        all_dfs.append(df)
+        if os.path.exists(file):
+            print(f"Reading file: {file}")
+            df = pd.read_csv(file)
+            print(f"Columns in {file}: {df.columns.tolist()}")
+            gw_number_match = re.search(r'GW_(\d+)', file)
+            if gw_number_match:
+                gw_number = gw_number_match.group(1)
+                df['GW'] = gw_number
+                all_dfs.append(df)
+            else:
+                print(f"Could not extract GW number from {file}")
+        else:
+            print(f"File not found: {file}")
 
     if not all_dfs:
         return None
 
-    merged_df = pd.concat(all_dfs, ignore_index=True)
+    merged_df = pd.concat(all_dfs, ignore_index=True, join='outer')
+    print(f"Columns in merged_df: {merged_df.columns.tolist()}")
     return merged_df
 
 def main():


### PR DESCRIPTION
This change addresses an issue where the `merge_gws.py` script was not including the 'Bonus' column in the final `merged_gws.csv` file.

The script has been made more robust by:
- Explicitly setting `join='outer'` in the `pd.concat` call to ensure all columns from all input files are preserved.
- Adding logging to provide better visibility into the merge process for future debugging.