### PR TITLE
Fix: Make GitHub Actions workflow more robust

### DIFF
--- a/.github/workflows/weekly-run.yml
+++ b/.github/workflows/weekly-run.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -36,16 +38,13 @@ jobs:
             FPL_Data_*/*.csv
 
       - name: Commit and push results
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          git config --global user.email "bmambwe777@gmail.com"
-          git config --global user.name "Dante777bm"
-          git add FPL_Data_*/*.csv
-          # Check if there are changes to commit
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          git add -A
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
             git commit -m "Auto-commit latest FPL data"
-            git push https://Dante777bm:${GH_PAT}@github.com/Dante777bm/fpl-data-collector.git main
+            git push
           fi


### PR DESCRIPTION
This change addresses potential errors in the `weekly-run.yml` workflow by:
1.  Providing the `GH_PAT` secret to the `checkout` action, which is the standard way to authenticate for pushes.
2.  Generalizing the git user configuration to use a generic GitHub Action user.
3.  Simplifying the `git add` command to `git add -A` to robustly stage all changes.
4.  Simplifying the `git push` command to `git push`, which will push to the correct repository when run from the checkout action's context.

These changes will make the workflow more reliable and prevent errors related to permissions or file paths, especially when run from a forked repository or when no new data is generated.