### PR TITLE
ci: Fix git push error in workflow

### DIFF
--- a/.github/workflows/weekly-run.yml
+++ b/.github/workflows/weekly-run.yml
@@ -46,5 +46,6 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "Auto-commit latest FPL data"
+            git pull --rebase
             git push
           fi


### PR DESCRIPTION
The GitHub Actions workflow was failing to push changes because the remote branch had been updated. This change adds a 'git pull --rebase' command to the workflow to update the local branch before pushing, which will prevent this error.