### PR TITLE
Fix: Prevent merge conflict in daily data collection workflow

### DIFF
--- a/.github/workflows/weekly-run.yml
+++ b/.github/workflows/weekly-run.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT }}
 
+      - name: Pull latest changes
+        run: git pull
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -47,6 +50,5 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "Auto-commit latest FPL data"
-            git pull --rebase
             git push
           fi


### PR DESCRIPTION
The GitHub Actions workflow for daily data collection was failing due to a merge conflict during the `git pull --rebase` step. This happened because the workflow would generate and commit data before pulling the latest changes from the remote, leading to conflicts if the remote had also been updated.

This change fixes the issue by modifying the workflow to pull the latest changes from the repository *before* running the data collection scripts. This ensures that the scripts are always working with the most up-to-date data, which prevents the merge conflict from occurring. The problematic `git pull --rebase` command has been removed from the commit step.